### PR TITLE
108 add support list parsing

### DIFF
--- a/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
@@ -1,0 +1,26 @@
+package seedu.address.logic.commands.interview;
+
+import seedu.address.commons.core.DataType;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.model.Model;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
+
+public class ListInterviewCommand extends ListCommand {
+
+    public static final String MESSAGE_SUCCESS = "Listed all interviews";
+
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);
+        return new CommandResult(MESSAGE_SUCCESS, getCommandDataType());
+    }
+
+    @Override
+    public DataType getCommandDataType() {
+        return DataType.INTERVIEW;
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
@@ -1,12 +1,12 @@
 package seedu.address.logic.commands.interview;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
+
 import seedu.address.commons.core.DataType;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.model.Model;
-
-import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
 
 public class ListInterviewCommand extends ListCommand {
 

--- a/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
@@ -1,0 +1,21 @@
+package seedu.address.logic.commands.position;
+
+import seedu.address.commons.core.DataType;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.model.Model;
+
+public class ListPositionCommand extends ListCommand {
+    public static final String MESSAGE_SUCCESS = ""; //TODO
+
+    @Override
+    public CommandResult execute(Model model) {
+        //TODO
+        return null;
+    }
+
+    @Override
+    public DataType getCommandDataType() {
+        return DataType.POSITION;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -14,7 +14,6 @@ import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.applicant.ListApplicantCommand;
 import seedu.address.logic.commands.help.HelpCommand;
 import seedu.address.logic.parser.applicants.EditApplicantCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -63,7 +63,7 @@ public class AddressBookParser {
             return new FindCommandParser().parse(arguments);
 
         case ListCommand.COMMAND_WORD:
-            return new ListApplicantCommand(); //TODO: Create list parser to call different ListCommands
+            return new ListCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -10,15 +10,11 @@ import seedu.address.logic.commands.interview.ListInterviewCommand;
 import seedu.address.logic.commands.position.ListPositionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
-
-
-
 public class ListCommandParser implements Parser<ListCommand> {
 
     /**
-     * Parses the given {@code String} of arguments in the context of the AddApplicantCommand,
-     * calls the respective AddXCommandParsers according to the flag specified
-     * and returns an AddApplicantCommand object for execution.
+     * Parses the given {@code String} of arguments for data type flag and calls the respective
+     * ListXCommand according to the flag specified.
      * @throws ParseException if the user input does not conform the expected format
      */
     @Override

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.parser;
+
+import seedu.address.logic.commands.ListCommand;
+import seedu.address.logic.commands.applicant.ListApplicantCommand;
+import seedu.address.logic.commands.interview.ListInterviewCommand;
+import seedu.address.logic.commands.position.ListPositionCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+
+import static seedu.address.commons.core.DataTypeFlags.FLAG_APPLICANT;
+import static seedu.address.commons.core.DataTypeFlags.FLAG_INTERVIEW;
+import static seedu.address.commons.core.DataTypeFlags.FLAG_POSITION;
+
+public class ListCommandParser implements Parser<ListCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the AddApplicantCommand,
+     * calls the respective AddXCommandParsers according to the flag specified
+     * and returns an AddApplicantCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public ListCommand parse(String args) throws ParseException {
+        char flag = ArgumentTokenizer.getFlag(args.trim());
+
+        if (flag == FLAG_APPLICANT) {
+            return new ListApplicantCommand();
+        } else if (flag == FLAG_INTERVIEW) {
+            return new ListInterviewCommand();
+        } else if (flag == FLAG_POSITION) {
+            return new ListPositionCommand();
+        }
+
+        return null;
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -1,5 +1,9 @@
 package seedu.address.logic.parser;
 
+import static seedu.address.commons.core.DataTypeFlags.FLAG_APPLICANT;
+import static seedu.address.commons.core.DataTypeFlags.FLAG_INTERVIEW;
+import static seedu.address.commons.core.DataTypeFlags.FLAG_POSITION;
+
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.applicant.ListApplicantCommand;
 import seedu.address.logic.commands.interview.ListInterviewCommand;
@@ -7,9 +11,7 @@ import seedu.address.logic.commands.position.ListPositionCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 
-import static seedu.address.commons.core.DataTypeFlags.FLAG_APPLICANT;
-import static seedu.address.commons.core.DataTypeFlags.FLAG_INTERVIEW;
-import static seedu.address.commons.core.DataTypeFlags.FLAG_POSITION;
+
 
 public class ListCommandParser implements Parser<ListCommand> {
 


### PR DESCRIPTION
I created support for list parsing of appropriate types. Now, users can add a flag to the `list` command, such as `list -i`, to tell which data type they want to list.

Closes #108