### PR TITLE
Add support for deleting interviews

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -8,6 +8,7 @@ public class Messages {
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The applicant index provided is invalid";
+    public static final String MESSAGE_INVALID_INTERVIEW_DISPLAYED_INDEX = "The interview index provided is invalid";
     public static final String MESSAGE_INVALID_POSITION_DISPLAYED_INDEX = "The position index provided is invalid";
     public static final String MESSAGE_INVALID_FLAG = "Flag is invalid!";
     public static final String MESSAGE_NO_FLAG = "No flag is found!";

--- a/src/main/java/seedu/address/logic/commands/interview/DeleteInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/DeleteInterviewCommand.java
@@ -1,0 +1,57 @@
+package seedu.address.logic.commands.interview;
+
+import static java.util.Objects.requireNonNull;
+
+import java.util.List;
+
+import seedu.address.commons.core.DataType;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.interview.Interview;
+
+public class DeleteInterviewCommand extends DeleteCommand {
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + " -i : Deletes the interview identified by the index number used in the displayed interview list.\n"
+            + "Parameters: INDEX (must be a positive integer)\n"
+            + "Example: " + COMMAND_WORD + " -i 1";
+
+    public static final String MESSAGE_DELETE_INTERVIEW_SUCCESS = "Deleted Interview: %1$s";
+
+    private final Index targetIndex;
+
+    public DeleteInterviewCommand(Index targetIndex) {
+        this.targetIndex = targetIndex;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Interview> lastShownList = model.getFilteredInterviewList();
+
+        if (targetIndex.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_INTERVIEW_DISPLAYED_INDEX);
+        }
+
+        Interview interviewToDelete = lastShownList.get(targetIndex.getZeroBased());
+        model.deleteInterview(interviewToDelete);
+        return new CommandResult(String.format(MESSAGE_DELETE_INTERVIEW_SUCCESS, interviewToDelete),
+                getCommandDataType());
+    }
+
+    @Override
+    public DataType getCommandDataType() {
+        return DataType.INTERVIEW;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DeleteInterviewCommand // instanceof handles nulls
+                && targetIndex.equals(((DeleteInterviewCommand) other).targetIndex)); // state check
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.commons.core.DataTypeFlags.FLAG_POSITION;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.parser.applicants.DeleteApplicantCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.interview.DeleteInterviewCommandParser;
 
 /**
  * Parses delete command and calls the respective DeleteXCommandParsers according to the flag.
@@ -26,7 +27,7 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
         if (flag == FLAG_APPLICANT) {
             return new DeleteApplicantCommandParser().parse(argsWithoutFlag);
         } else if (flag == FLAG_INTERVIEW) {
-            // calls delete interview command parser
+            return new DeleteInterviewCommandParser().parse(argsWithoutFlag);
         } else if (flag == FLAG_POSITION) {
             // calls delete position command parser
         }

--- a/src/main/java/seedu/address/logic/parser/interview/DeleteInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/interview/DeleteInterviewCommandParser.java
@@ -1,0 +1,27 @@
+package seedu.address.logic.parser.interview;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.interview.DeleteInterviewCommand;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+public class DeleteInterviewCommandParser implements Parser<DeleteInterviewCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the DeleteInterviewCommand
+     * and returns a DeleteInterviewCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public DeleteInterviewCommand parse(String args) throws ParseException {
+        try {
+            Index index = ParserUtil.parseIndex(args);
+            return new DeleteInterviewCommand(index);
+        } catch (ParseException pe) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, DeleteInterviewCommand.MESSAGE_USAGE), pe);
+        }
+    }
+}

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -132,6 +132,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Removes {@code key} from this {@code AddressBook}.
+     * {@code key} must exist in the address book.
+     */
+    public void removeInterview(Interview key) {
+        interviews.remove(key);
+    }
+
+    /**
      * Adds an interview to the address book.
      * The interview must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -96,8 +96,8 @@ public interface Model {
     boolean hasInterview(Interview interview);
 
     /**
-     * Deletes the given applicant.
-     * The applicant must exist in the address book.
+     * Deletes the given interview.
+     * The interview must exist in the address book.
      */
     void deleteInterview(Interview target);
 

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -96,6 +96,12 @@ public interface Model {
     boolean hasInterview(Interview interview);
 
     /**
+     * Deletes the given applicant.
+     * The applicant must exist in the address book.
+     */
+    void deleteInterview(Interview target);
+
+    /**
      * Adds the given interview.
      * {@code interview} must not already exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -123,6 +123,11 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public void deleteInterview(Interview target) {
+        addressBook.removeInterview(target);
+    }
+
+    @Override
     public void addInterview(Interview interview) {
         addressBook.addInterview(interview);
         updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);

--- a/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
@@ -198,6 +198,10 @@ public class AddApplicantCommandTest {
             throw new AssertionError("This method should not be called.");
         }
 
+        @Override
+        public void deleteInterview(Interview target) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**


### PR DESCRIPTION
I added support to delete interviews by index.

We might have to consider the case of deleting interviews when a corresponding position / applicant is deleted. This commit does not implement that portion yet.

Closes #102 