### PR TITLE
Enable assertions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,4 +69,8 @@ shadowJar {
     archiveName = 'addressbook.jar'
 }
 
+run {
+    enableAssertions = true
+}
+
 defaultTasks 'clean', 'test'


### PR DESCRIPTION
Allows us to verify the assumptions we made about program state so the runtime can verify them.