### PR TITLE
Cascade delete for applicant and position to delete related interviews 

### DIFF
--- a/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicantCommand.java
@@ -55,6 +55,9 @@ public class DeleteApplicantCommand extends DeleteCommand {
                 getCommandDataType());
     }
 
+    /**
+     * Deletes interviews which are for the applicant to delete.
+     */
     private int deleteApplicantsInterview(Model model, Applicant applicantToDelete) {
         ObservableList<Interview> interviewList = model.getAddressBook().getInterviewList();
         ArrayList<Interview> interviewsToDelete = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicantCommand.java
@@ -2,8 +2,10 @@ package seedu.address.logic.commands.applicant;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.DataType;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -12,6 +14,7 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.applicant.Applicant;
+import seedu.address.model.interview.Interview;
 
 /**
  * Deletes a applicant identified using it's displayed index from the address book.
@@ -24,6 +27,8 @@ public class DeleteApplicantCommand extends DeleteCommand {
             + "Example: " + COMMAND_WORD + " -a 1";
 
     public static final String MESSAGE_DELETE_PERSON_SUCCESS = "Deleted Applicant: %1$s";
+
+    public static final String MESSAGE_DELETE_INTERVIEWS = "Deleted %d related interview(s)";
 
     private final Index targetIndex;
 
@@ -41,9 +46,32 @@ public class DeleteApplicantCommand extends DeleteCommand {
         }
 
         Applicant applicantToDelete = lastShownList.get(targetIndex.getZeroBased());
+        int deleteInterviewCount = deleteApplicantsInterview(model, applicantToDelete);
+
         model.deletePerson(applicantToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_PERSON_SUCCESS, applicantToDelete),
+        return new CommandResult(
+                String.format(MESSAGE_DELETE_PERSON_SUCCESS, applicantToDelete) + "\n"
+                        + String.format(MESSAGE_DELETE_INTERVIEWS, deleteInterviewCount),
                 getCommandDataType());
+    }
+
+    private int deleteApplicantsInterview(Model model, Applicant applicantToDelete) {
+        ObservableList<Interview> interviewList = model.getAddressBook().getInterviewList();
+        ArrayList<Interview> interviewsToDelete = new ArrayList<>();
+
+        int deleteCount = 0;
+        for (Interview i : interviewList) {
+            if (i.isInterviewForApplicant(applicantToDelete)) {
+                interviewsToDelete.add(i);
+                deleteCount++;
+            }
+        }
+
+        for (Interview i : interviewsToDelete) {
+            model.deleteInterview(i);
+        }
+
+        return deleteCount;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicantCommand.java
@@ -17,7 +17,8 @@ import seedu.address.model.applicant.Applicant;
 import seedu.address.model.interview.Interview;
 
 /**
- * Deletes a applicant identified using it's displayed index from the address book.
+ * Deletes an applicant identified using it's displayed index from the address book,
+ * and the interviews associated with the applicant as well.
  */
 public class DeleteApplicantCommand extends DeleteCommand {
 
@@ -57,16 +58,16 @@ public class DeleteApplicantCommand extends DeleteCommand {
 
     /**
      * Deletes interviews which are for the applicant to delete.
+     *
+     * @return Number of interviews deleted.
      */
     private int deleteApplicantsInterview(Model model, Applicant applicantToDelete) {
         ObservableList<Interview> interviewList = model.getAddressBook().getInterviewList();
         ArrayList<Interview> interviewsToDelete = new ArrayList<>();
 
-        int deleteCount = 0;
         for (Interview i : interviewList) {
             if (i.isInterviewForApplicant(applicantToDelete)) {
                 interviewsToDelete.add(i);
-                deleteCount++;
             }
         }
 
@@ -74,7 +75,7 @@ public class DeleteApplicantCommand extends DeleteCommand {
             model.deleteInterview(i);
         }
 
-        return deleteCount;
+        return interviewsToDelete.size();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/position/DeletePositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/DeletePositionCommand.java
@@ -2,8 +2,10 @@ package seedu.address.logic.commands.position;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.ArrayList;
 import java.util.List;
 
+import javafx.collections.ObservableList;
 import seedu.address.commons.core.DataType;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
@@ -11,6 +13,8 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
+import seedu.address.model.applicant.Applicant;
+import seedu.address.model.interview.Interview;
 import seedu.address.model.position.Position;
 
 public class DeletePositionCommand extends DeleteCommand {
@@ -21,6 +25,8 @@ public class DeletePositionCommand extends DeleteCommand {
             + "Example: " + COMMAND_WORD + " -p 1";
 
     public static final String MESSAGE_DELETE_POSITION_SUCCESS = "Deleted Position: %1$s";
+
+    public static final String MESSAGE_DELETE_INTERVIEWS = "Deleted %d related interview(s)";
 
     private final Index targetIndex;
 
@@ -38,9 +44,34 @@ public class DeletePositionCommand extends DeleteCommand {
         }
 
         Position positionToDelete = lastShownList.get(targetIndex.getZeroBased());
+        int deleteInterviewCount = deletePositionsInterview(model, positionToDelete);
+
         model.deletePosition(positionToDelete);
-        return new CommandResult(String.format(MESSAGE_DELETE_POSITION_SUCCESS, positionToDelete),
+        return new CommandResult(String.format(MESSAGE_DELETE_POSITION_SUCCESS, positionToDelete) + "\n"
+                    + String.format(MESSAGE_DELETE_INTERVIEWS, deleteInterviewCount),
                 getCommandDataType());
+    }
+
+    /**
+     * Deletes interviews which are for the position to delete.
+     */
+    private int deletePositionsInterview(Model model, Position positionToDelete) {
+        ObservableList<Interview> interviewList = model.getAddressBook().getInterviewList();
+        ArrayList<Interview> interviewsToDelete = new ArrayList<>();
+
+        int deleteCount = 0;
+        for (Interview i : interviewList) {
+            if (i.isInterviewForPosition(positionToDelete)) {
+                interviewsToDelete.add(i);
+                deleteCount++;
+            }
+        }
+
+        for (Interview i : interviewsToDelete) {
+            model.deleteInterview(i);
+        }
+
+        return deleteCount;
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/position/DeletePositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/DeletePositionCommand.java
@@ -13,7 +13,6 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
-import seedu.address.model.applicant.Applicant;
 import seedu.address.model.interview.Interview;
 import seedu.address.model.position.Position;
 

--- a/src/main/java/seedu/address/logic/commands/position/DeletePositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/DeletePositionCommand.java
@@ -16,6 +16,10 @@ import seedu.address.model.Model;
 import seedu.address.model.interview.Interview;
 import seedu.address.model.position.Position;
 
+/**
+ * Deletes a position identified using it's displayed index from the address book,
+ * and the interviews associated with the position as well.
+ */
 public class DeletePositionCommand extends DeleteCommand {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
@@ -53,16 +57,16 @@ public class DeletePositionCommand extends DeleteCommand {
 
     /**
      * Deletes interviews which are for the position to delete.
+     *
+     * @return Number of interviews deleted.
      */
     private int deletePositionsInterview(Model model, Position positionToDelete) {
         ObservableList<Interview> interviewList = model.getAddressBook().getInterviewList();
         ArrayList<Interview> interviewsToDelete = new ArrayList<>();
 
-        int deleteCount = 0;
         for (Interview i : interviewList) {
             if (i.isInterviewForPosition(positionToDelete)) {
                 interviewsToDelete.add(i);
-                deleteCount++;
             }
         }
 
@@ -70,7 +74,7 @@ public class DeletePositionCommand extends DeleteCommand {
             model.deleteInterview(i);
         }
 
-        return deleteCount;
+        return interviewsToDelete.size();
     }
 
     @Override

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -89,6 +89,7 @@ public class Interview {
                 .append(getDate())
                 .append("; Position: ")
                 .append(position.getPositionName())
+                .append("; Status: ")
                 .append(getStatus());
         return builder.toString();
     }

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -58,7 +58,7 @@ public class Interview {
      * Checks if the interview is for the specified position.
      */
     public boolean isInterviewForPosition(Position p) {
-        return position.equals(p);
+        return position.isSamePosition(p);
     }
 
     /**

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -43,7 +43,23 @@ public class Interview {
         return position;
     }
 
-    public Status getStatus() { return status; }
+    public Status getStatus() {
+        return status;
+    }
+
+    /**
+     * Checks if the interview is for the specified applicant.
+     */
+    public boolean isInterviewForApplicant(Applicant a) {
+        return applicant.isSamePerson(a);
+    }
+
+    /**
+     * Checks if the interview is for the specified position.
+     */
+    public boolean isInterviewForPosition(Position p) {
+        return position.equals(p);
+    }
 
     /**
      * Returns true if both interviews have the same data fields.

--- a/src/test/java/seedu/address/logic/commands/DeleteApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteApplicantCommandTest.java
@@ -32,7 +32,9 @@ public class DeleteApplicantCommandTest {
         Applicant applicantToDelete = model.getFilteredApplicantList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteApplicantCommand deleteApplicantCommand = new DeleteApplicantCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteApplicantCommand.MESSAGE_DELETE_PERSON_SUCCESS, applicantToDelete);
+        String expectedMessage =
+                String.format(DeleteApplicantCommand.MESSAGE_DELETE_PERSON_SUCCESS, applicantToDelete) + "\n"
+                        + String.format(DeleteApplicantCommand.MESSAGE_DELETE_INTERVIEWS, 0);
 
         ModelManager expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(applicantToDelete);
@@ -55,7 +57,9 @@ public class DeleteApplicantCommandTest {
         Applicant applicantToDelete = model.getFilteredApplicantList().get(INDEX_FIRST_PERSON.getZeroBased());
         DeleteApplicantCommand deleteApplicantCommand = new DeleteApplicantCommand(INDEX_FIRST_PERSON);
 
-        String expectedMessage = String.format(DeleteApplicantCommand.MESSAGE_DELETE_PERSON_SUCCESS, applicantToDelete);
+        String expectedMessage =
+                String.format(DeleteApplicantCommand.MESSAGE_DELETE_PERSON_SUCCESS, applicantToDelete) + "\n"
+                        + String.format(DeleteApplicantCommand.MESSAGE_DELETE_INTERVIEWS, 0);
 
         Model expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
         expectedModel.deletePerson(applicantToDelete);


### PR DESCRIPTION
I have added in a method to delete the related interviews, under `DeleteApplicantCommand.java` and `DeletePositionCommand.java` when deleting applicant and position respectively.

It works well on my side and I have included in the message to show how many interviews are deleted as well.

<img width="225" alt="image" src="https://user-images.githubusercontent.com/68813082/159772255-b7b68896-8fcf-47f3-af22-2feebcd8d3a7.png">
