### PR TITLE
Add logging for add command parser

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -4,16 +4,23 @@ import static seedu.address.commons.core.DataTypeFlags.FLAG_APPLICANT;
 import static seedu.address.commons.core.DataTypeFlags.FLAG_INTERVIEW;
 import static seedu.address.commons.core.DataTypeFlags.FLAG_POSITION;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.applicants.AddApplicantCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.interview.AddInterviewCommandParser;
 import seedu.address.logic.parser.position.AddPositionCommandParser;
+import seedu.address.ui.PositionListPanel;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 /**
  * Parses add command and calls the respective AddXCommandParsers according to the flag.
  */
 public class AddCommandParser implements Parser<AddCommand> {
+
+    private final Logger logger = LogsCenter.getLogger(AddCommandParser.class);
 
     /**
      * Parses the given {@code String} of arguments in the context of the AddApplicantCommand,
@@ -26,13 +33,16 @@ public class AddCommandParser implements Parser<AddCommand> {
         String argsWithoutFlag = ArgumentTokenizer.removeFlag(args.trim());
 
         if (flag == FLAG_APPLICANT) {
+            logger.log(Level.INFO, "Add command for applicant parsed");
             return new AddApplicantCommandParser().parse(argsWithoutFlag);
         } else if (flag == FLAG_INTERVIEW) {
+            logger.log(Level.INFO, "Add command for interview parsed");
             return new AddInterviewCommandParser().parse(argsWithoutFlag);
         } else if (flag == FLAG_POSITION) {
+            logger.log(Level.INFO, "Add command for position parsed");
             return new AddPositionCommandParser().parse(argsWithoutFlag);
         }
-
+        logger.log(Level.WARNING, "Add command did not find valid flag and did not throw an exception");
         return null;
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddCommandParser.java
@@ -4,16 +4,16 @@ import static seedu.address.commons.core.DataTypeFlags.FLAG_APPLICANT;
 import static seedu.address.commons.core.DataTypeFlags.FLAG_INTERVIEW;
 import static seedu.address.commons.core.DataTypeFlags.FLAG_POSITION;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.parser.applicants.AddApplicantCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.interview.AddInterviewCommandParser;
 import seedu.address.logic.parser.position.AddPositionCommandParser;
-import seedu.address.ui.PositionListPanel;
 
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 /**
  * Parses add command and calls the respective AddXCommandParsers according to the flag.


### PR DESCRIPTION
Adds logging for add command parser, so we can deliberately record information for future reference. 

In particular, since we determined that it should never reach the `return null` portion, I added a logging with a warning to signal that something has gone wrong.