### PR TITLE
Add logging to record information of deleted interview from cascading

### DIFF
--- a/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/DeleteApplicantCommand.java
@@ -4,9 +4,12 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.DataType;
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandResult;
@@ -32,6 +35,8 @@ public class DeleteApplicantCommand extends DeleteCommand {
     public static final String MESSAGE_DELETE_INTERVIEWS = "Deleted %d related interview(s)";
 
     private final Index targetIndex;
+
+    private final Logger logger = LogsCenter.getLogger(DeleteApplicantCommand.class);
 
     public DeleteApplicantCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
@@ -73,6 +78,7 @@ public class DeleteApplicantCommand extends DeleteCommand {
 
         for (Interview i : interviewsToDelete) {
             model.deleteInterview(i);
+            logger.log(Level.INFO, String.format("Deleted interview: %1$s", i));
         }
 
         return interviewsToDelete.size();

--- a/src/main/java/seedu/address/logic/commands/position/DeletePositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/DeletePositionCommand.java
@@ -4,9 +4,12 @@ import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.DataType;
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.CommandResult;
@@ -32,6 +35,8 @@ public class DeletePositionCommand extends DeleteCommand {
     public static final String MESSAGE_DELETE_INTERVIEWS = "Deleted %d related interview(s)";
 
     private final Index targetIndex;
+
+    private final Logger logger = LogsCenter.getLogger(DeletePositionCommand.class);
 
     public DeletePositionCommand(Index targetIndex) {
         this.targetIndex = targetIndex;
@@ -72,6 +77,7 @@ public class DeletePositionCommand extends DeleteCommand {
 
         for (Interview i : interviewsToDelete) {
             model.deleteInterview(i);
+            logger.log(Level.INFO, String.format("Deleted interview: %1$s", i));
         }
 
         return interviewsToDelete.size();


### PR DESCRIPTION
I added logging to record information of the interview which is deleted due to the deletion of an applicant or a position. As the interview is not deleted with a command, the information of the deletion is not logged.

<img width="921" alt="image" src="https://user-images.githubusercontent.com/68813082/159976594-82e57524-44ee-4657-be0c-c7b73fdc12ef.png">
