### PR TITLE
Fix bug of interviews having conflicting timing for applicant

### DIFF
--- a/src/main/java/seedu/address/logic/commands/interview/AddInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/AddInterviewCommand.java
@@ -29,6 +29,9 @@ public class AddInterviewCommand extends AddCommand {
 
     public static final String MESSAGE_SUCCESS = "New interview added: %1$s";
     public static final String MESSAGE_DUPLICATE_INTERVIEW = "This interview already exists in the address book";
+    public static final String MESSAGE_CONFLICTING_INTERVIEW = "This interview would cause a conflict of timings with"
+            + " a current interview in the address book. Interviews must be "
+            + "at least 1 hour apart for the same candidate.";
 
     private final Index applicantIndex;
     private final LocalDateTime date;
@@ -64,6 +67,10 @@ public class AddInterviewCommand extends AddCommand {
         Position positionInInterview = lastShownPositionList.get(positionIndex.getZeroBased());
 
         Interview interviewToAdd = new Interview(applicantInInterview, date, positionInInterview);
+
+        if (model.hasConflictingInterview(interviewToAdd)) {
+            throw new CommandException(MESSAGE_CONFLICTING_INTERVIEW);
+        }
 
         if (model.hasInterview(interviewToAdd)) {
             throw new CommandException(MESSAGE_DUPLICATE_INTERVIEW);

--- a/src/main/java/seedu/address/logic/commands/interview/EditInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/EditInterviewCommand.java
@@ -39,6 +39,9 @@ public class EditInterviewCommand extends EditCommand {
     public static final String MESSAGE_NOT_EDITED = "At least one field in Interview to edit must be provided.";
     public static final String MESSAGE_DUPLICATE_INTERVIEW = "This interview already exists in HireLah.";
     public static final String MESSAGE_EDIT_INTERVIEW_SUCCESS = "Edited interview: %1$s";
+    public static final String MESSAGE_CONFLICTING_INTERVIEW = "This interview would cause a conflict of timings with"
+            + " a current interview in the address book. Interviews must be "
+            + "at least 1 hour apart for the same candidate.";
 
     private final Index index;
     private final EditInterviewDescriptor editInterviewDescriptor;
@@ -105,6 +108,10 @@ public class EditInterviewCommand extends EditCommand {
 
         Interview interviewToEdit = lastShownList.get(index.getZeroBased());
         Interview editedInterview = createEditedInterview(interviewToEdit, editInterviewDescriptor, model);
+
+        if (model.hasConflictingInterview(editedInterview)) {
+            throw new CommandException(MESSAGE_CONFLICTING_INTERVIEW);
+        }
 
         if (!interviewToEdit.equals(editedInterview) && model.hasInterview(editedInterview)) {
             throw new CommandException(MESSAGE_DUPLICATE_INTERVIEW);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -132,6 +132,14 @@ public class AddressBook implements ReadOnlyAddressBook {
     }
 
     /**
+     * Returns true if an interview has a conflict in timing as {@code interview} exists in the address book.
+     */
+    public boolean hasConflictingInterview(Interview i) {
+        requireNonNull(i);
+        return interviews.containsConflict(i);
+    }
+
+    /**
      * Removes {@code key} from this {@code AddressBook}.
      * {@code key} must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -96,6 +96,11 @@ public interface Model {
     boolean hasInterview(Interview interview);
 
     /**
+     * Returns true if an applicant already has an interview for that timeslot.
+     */
+    boolean hasConflictingInterview(Interview interview);
+
+    /**
      * Deletes the given interview.
      * The interview must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -123,6 +123,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasConflictingInterview(Interview interview) {
+        requireAllNonNull(interview);
+        return addressBook.hasConflictingInterview(interview);
+    }
+
+    @Override
     public void deleteInterview(Interview target) {
         addressBook.removeInterview(target);
     }

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -3,6 +3,7 @@ package seedu.address.model.interview;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
+import java.time.temporal.ChronoUnit;
 
 import seedu.address.model.applicant.Applicant;
 import seedu.address.model.position.Position;
@@ -59,6 +60,15 @@ public class Interview {
      */
     public boolean isInterviewForPosition(Position p) {
         return position.isSamePosition(p);
+    }
+
+    /**
+     * Checks if the given interview will conflict with the current interview.
+     */
+    public boolean isConflictingInterview(Interview i) {
+        return i.isInterviewForApplicant(this.applicant)
+                && !(i.date.isBefore(this.date.minus(59, ChronoUnit.MINUTES))
+                        || i.date.isAfter(this.date.plusMinutes(59)));
     }
 
     /**

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -3,7 +3,6 @@ package seedu.address.model.interview;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.LocalDateTime;
-import java.time.temporal.ChronoUnit;
 
 import seedu.address.model.applicant.Applicant;
 import seedu.address.model.position.Position;
@@ -66,8 +65,10 @@ public class Interview {
      * Checks if the given interview will conflict with the current interview.
      */
     public boolean isConflictingInterview(Interview i) {
-        return i.isInterviewForApplicant(this.applicant)
-                && !(i.date.isBefore(this.date.minus(59, ChronoUnit.MINUTES))
+        boolean isSameApplicant = i.isInterviewForApplicant(this.applicant);
+
+        // Interview has to be at least 1 hour before or after the current interview time for it not to clash
+        return isSameApplicant && !(i.date.isBefore(this.date.minusMinutes(59))
                         || i.date.isAfter(this.date.plusMinutes(59)));
     }
 

--- a/src/main/java/seedu/address/model/interview/UniqueInterviewList.java
+++ b/src/main/java/seedu/address/model/interview/UniqueInterviewList.java
@@ -24,6 +24,19 @@ public class UniqueInterviewList implements Iterable<Interview> {
     }
 
     /**
+     * Returns true if the list contains an interview which has a conflict in timing as the given argument.
+     */
+    public boolean containsConflict(Interview toCheck) {
+        requireNonNull(toCheck);
+        for (Interview i : internalList) {
+            if (i.isConflictingInterview(toCheck)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
      * Adds an interview to the list.
      * The interview must not already exist in the list.
      */

--- a/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
@@ -189,6 +189,11 @@ public class AddApplicantCommandTest {
         }
 
         @Override
+        public boolean hasConflictingInterview(Interview interview) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void setPosition(Position target, Position editedPosition) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
An applicant cannot have interviews within the same 1 hour timeslot.

For example, if he has an interview at 11am, he cannot have an interview (regardless of position) from 10.01am till 11.59am. Thus, we will block adding of interviews during that time frame.

Could you guys help me check whether the scheduling logic should be implemented in `Interview` or `UniqueInterviewList`?
Can I deprecate `hasInterview` in `AddInterviewCommand` as well? Seems like a subset to me.

Closes #101  