### PR TITLE
Implement filter feature for list command

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -7,6 +7,8 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
+    public static final String MESSAGE_INVALID_DATETIME = "Date time format should be yyyy-MM-dd HH:mm";
+    public static final String MESSAGE_INVALID_DATE = "Date format should be yyyy-MM-dd";
     public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The applicant index provided is invalid";
     public static final String MESSAGE_INVALID_INTERVIEW_DISPLAYED_INDEX = "The interview index provided is invalid";
     public static final String MESSAGE_INVALID_POSITION_DISPLAYED_INDEX = "The position index provided is invalid";

--- a/src/main/java/seedu/address/logic/FilterArgument.java
+++ b/src/main/java/seedu/address/logic/FilterArgument.java
@@ -1,0 +1,54 @@
+package seedu.address.logic;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class FilterArgument {
+
+    public static final String MESSAGE_CONSTRAINTS =
+            "Filter arguments should only contain alphanumeric characters and spaces, and it should not be blank";
+
+    /*
+     * The first character of the filter argument must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    public final String filterArgument;
+
+    /**
+     * Constructs a {@code FilterArgument}.
+     *
+     * @param argument A valid argument.
+     */
+    public FilterArgument(String argument) {
+        requireNonNull(argument);
+        checkArgument(isValidFilterArgument(argument), MESSAGE_CONSTRAINTS);
+        filterArgument = argument;
+    }
+
+    /**
+     * Returns true if a given string is a valid filter argument.
+     */
+    public static boolean isValidFilterArgument(String test) {
+        return test.matches(VALIDATION_REGEX);
+    }
+
+
+    @Override
+    public String toString() {
+        return filterArgument;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterArgument // instanceof handles nulls
+                && filterArgument.equals(((FilterArgument) other).filterArgument)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return filterArgument.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/logic/FilterArgument.java
+++ b/src/main/java/seedu/address/logic/FilterArgument.java
@@ -5,14 +5,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 
 public class FilterArgument {
 
-    public static final String MESSAGE_CONSTRAINTS =
-            "Filter arguments should only contain alphanumeric characters and spaces, and it should not be blank";
-
-    /*
-     * The first character of the filter argument must not be a whitespace,
-     * otherwise " " (a blank string) becomes a valid input.
-     */
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+    public static final String MESSAGE_CONSTRAINTS = "Filter arguments should not be blank";
 
     public final String filterArgument;
 
@@ -23,17 +16,8 @@ public class FilterArgument {
      */
     public FilterArgument(String argument) {
         requireNonNull(argument);
-        checkArgument(isValidFilterArgument(argument), MESSAGE_CONSTRAINTS);
         filterArgument = argument;
     }
-
-    /**
-     * Returns true if a given string is a valid filter argument.
-     */
-    public static boolean isValidFilterArgument(String test) {
-        return test.matches(VALIDATION_REGEX);
-    }
-
 
     @Override
     public String toString() {

--- a/src/main/java/seedu/address/logic/FilterArgument.java
+++ b/src/main/java/seedu/address/logic/FilterArgument.java
@@ -1,7 +1,6 @@
 package seedu.address.logic;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
 
 public class FilterArgument {
 

--- a/src/main/java/seedu/address/logic/FilterArgument.java
+++ b/src/main/java/seedu/address/logic/FilterArgument.java
@@ -6,7 +6,7 @@ public class FilterArgument {
 
     public static final String MESSAGE_CONSTRAINTS = "Filter arguments should not be blank";
 
-    public final String filterArgument;
+    public final String argument;
 
     /**
      * Constructs a {@code FilterArgument}.
@@ -15,23 +15,23 @@ public class FilterArgument {
      */
     public FilterArgument(String argument) {
         requireNonNull(argument);
-        filterArgument = argument;
+        this.argument = argument;
     }
 
     @Override
     public String toString() {
-        return filterArgument;
+        return argument;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FilterArgument // instanceof handles nulls
-                && filterArgument.equals(((FilterArgument) other).filterArgument)); // state check
+                && argument.equals(((FilterArgument) other).argument)); // state check
     }
 
     @Override
     public int hashCode() {
-        return filterArgument.hashCode();
+        return argument.hashCode();
     }
 }

--- a/src/main/java/seedu/address/logic/FilterType.java
+++ b/src/main/java/seedu/address/logic/FilterType.java
@@ -34,8 +34,16 @@ public class FilterType {
         HashSet<String> applicantTypes = new HashSet<>();
         applicantTypes.add("name");
 
+        HashSet<String> positionTypes = new HashSet<>();
+        positionTypes.add("name");
+
+        HashSet<String> interviewTypes = new HashSet<>();
+        // to add
+
         HashMap<DataType, HashSet<String>> filterTypes = new HashMap<>();
         filterTypes.put(DataType.APPLICANT, applicantTypes);
+        filterTypes.put(DataType.POSITION, positionTypes);
+        filterTypes.put(DataType.INTERVIEW, interviewTypes);
 
         return filterTypes;
     }

--- a/src/main/java/seedu/address/logic/FilterType.java
+++ b/src/main/java/seedu/address/logic/FilterType.java
@@ -38,7 +38,9 @@ public class FilterType {
         positionTypes.add("name");
 
         HashSet<String> interviewTypes = new HashSet<>();
-        // to add
+        interviewTypes.add("appl");
+        interviewTypes.add("pos");
+        interviewTypes.add("date");
 
         HashMap<DataType, HashSet<String>> filterTypes = new HashMap<>();
         filterTypes.put(DataType.APPLICANT, applicantTypes);

--- a/src/main/java/seedu/address/logic/FilterType.java
+++ b/src/main/java/seedu/address/logic/FilterType.java
@@ -1,0 +1,66 @@
+package seedu.address.logic;
+
+import seedu.address.commons.core.DataType;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
+
+public class FilterType {
+
+    public static final String MESSAGE_CONSTRAINTS
+            = "Invalid filter type for the data specified\nRefer to help for the list of filter types";
+
+    public static final Map<DataType, HashSet<String>> validFilterTypes = loadFilterTypes();
+
+    public final String filterType;
+
+    /**
+     * Constructs a {@code FilterType}.
+     */
+    public FilterType(DataType dataType, String filterType) {
+        requireNonNull(dataType, filterType);
+        checkArgument(isValidFilterType(dataType, filterType), MESSAGE_CONSTRAINTS);
+        this.filterType = filterType;
+    }
+
+    /**
+     * Returns a map of data type to a valid filter type.
+     */
+    public static Map<DataType, HashSet<String>> loadFilterTypes() {
+        HashSet<String> applicantTypes = new HashSet<>();
+        applicantTypes.add("name");
+
+        HashMap<DataType, HashSet<String>> filterTypes = new HashMap<>();
+        filterTypes.put(DataType.APPLICANT, applicantTypes);
+
+        return filterTypes;
+    }
+
+    /**
+     * Returns true if a given string is a valid filter type for the given data type.
+     */
+    public static boolean isValidFilterType(DataType dataType, String filterType) {
+        return validFilterTypes.get(dataType).contains(filterType);
+    }
+
+    @Override
+    public String toString() {
+        return filterType;
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterType // instanceof handles nulls
+                && filterType.equals(((FilterType) other).filterType)); // state check
+    }
+
+    @Override
+    public int hashCode() {
+        return filterType.hashCode();
+    }
+}

--- a/src/main/java/seedu/address/logic/FilterType.java
+++ b/src/main/java/seedu/address/logic/FilterType.java
@@ -1,20 +1,20 @@
 package seedu.address.logic;
 
-import seedu.address.commons.core.DataType;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 
-import static java.util.Objects.requireNonNull;
-import static seedu.address.commons.util.AppUtil.checkArgument;
+import seedu.address.commons.core.DataType;
 
 public class FilterType {
 
-    public static final String MESSAGE_CONSTRAINTS
-            = "Invalid filter type for the data type specified\nRefer to help for the list of filter types";
+    public static final String MESSAGE_CONSTRAINTS = "Invalid filter type for the data type specified\n"
+            + "Refer to help for the list of filter types";
 
-    public static final Map<DataType, HashSet<String>> validFilterTypes = loadFilterTypes();
+    public static final Map<DataType, HashSet<String>> VALID_FILTER_TYPES = loadFilterTypes();
 
     public final String filterType;
 
@@ -54,7 +54,7 @@ public class FilterType {
      * Returns true if a given string is a valid filter type for the given data type.
      */
     public static boolean isValidFilterType(DataType dataType, String filterType) {
-        return validFilterTypes.get(dataType).contains(filterType);
+        return VALID_FILTER_TYPES.get(dataType).contains(filterType);
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/FilterType.java
+++ b/src/main/java/seedu/address/logic/FilterType.java
@@ -12,7 +12,7 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
 public class FilterType {
 
     public static final String MESSAGE_CONSTRAINTS
-            = "Invalid filter type for the data specified\nRefer to help for the list of filter types";
+            = "Invalid filter type for the data type specified\nRefer to help for the list of filter types";
 
     public static final Map<DataType, HashSet<String>> validFilterTypes = loadFilterTypes();
 

--- a/src/main/java/seedu/address/logic/FilterType.java
+++ b/src/main/java/seedu/address/logic/FilterType.java
@@ -16,15 +16,15 @@ public class FilterType {
 
     public static final Map<DataType, HashSet<String>> VALID_FILTER_TYPES = loadFilterTypes();
 
-    public final String filterType;
+    public final String type;
 
     /**
      * Constructs a {@code FilterType}.
      */
-    public FilterType(DataType dataType, String filterType) {
-        requireNonNull(dataType, filterType);
-        checkArgument(isValidFilterType(dataType, filterType), MESSAGE_CONSTRAINTS);
-        this.filterType = filterType;
+    public FilterType(DataType dataType, String type) {
+        requireNonNull(dataType, type);
+        checkArgument(isValidFilterType(dataType, type), MESSAGE_CONSTRAINTS);
+        this.type = type;
     }
 
     /**
@@ -59,18 +59,18 @@ public class FilterType {
 
     @Override
     public String toString() {
-        return filterType;
+        return type;
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
                 || (other instanceof FilterType // instanceof handles nulls
-                && filterType.equals(((FilterType) other).filterType)); // state check
+                && type.equals(((FilterType) other).type)); // state check
     }
 
     @Override
     public int hashCode() {
-        return filterType.hashCode();
+        return type.hashCode();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -5,7 +5,7 @@ import static java.util.Objects.requireNonNull;
 import seedu.address.commons.core.DataType;
 import seedu.address.commons.core.Messages;
 import seedu.address.model.Model;
-import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+import seedu.address.model.applicant.ApplicantNamePredicate;
 
 /**
  * Finds and lists all persons in address book whose name contains any of the argument keywords.
@@ -20,9 +20,9 @@ public class FindCommand extends Command {
             + "Parameters: KEYWORD [MORE_KEYWORDS]...\n"
             + "Example: " + COMMAND_WORD + " alice bob charlie";
 
-    private final NameContainsKeywordsPredicate predicate;
+    private final ApplicantNamePredicate predicate;
 
-    public FindCommand(NameContainsKeywordsPredicate predicate) {
+    public FindCommand(ApplicantNamePredicate predicate) {
         this.predicate = predicate;
     }
 

--- a/src/main/java/seedu/address/logic/commands/FindCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindCommand.java
@@ -29,7 +29,7 @@ public class FindCommand extends Command {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(predicate);
+        model.updateFilteredApplicantList(predicate);
         return new CommandResult(
                 String.format(Messages.MESSAGE_PERSONS_LISTED_OVERVIEW, model.getFilteredApplicantList().size()),
                 getCommandDataType());

--- a/src/main/java/seedu/address/logic/commands/applicant/EditApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/EditApplicantCommand.java
@@ -91,7 +91,7 @@ public class EditApplicantCommand extends EditCommand {
         }
 
         model.setPerson(applicantToEdit, editedApplicant);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.updateFilteredApplicantList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedApplicant), getCommandDataType());
     }
 

--- a/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
@@ -56,8 +56,7 @@ public class ListApplicantCommand extends ListCommand {
         requireNonNull(model);
 
         if (filterType != null && filterArgument != null) {
-            switch(filterType.filterType) {
-            case "name":
+            if (filterType.filterType.equals("name")) {
                 String[] nameKeywords = filterArgument.toString().split("\\s+");
                 Predicate<Applicant> predicate = new ApplicantNamePredicate(Arrays.asList(nameKeywords));
                 model.updateFilteredApplicantList(predicate);

--- a/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
@@ -4,21 +4,57 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.commons.core.DataType;
+import seedu.address.logic.FilterArgument;
+import seedu.address.logic.FilterType;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.model.Model;
+import seedu.address.model.applicant.Applicant;
+import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
 
 /**
  * Lists all persons in the address book to the user.
  */
 public class ListApplicantCommand extends ListCommand {
-    public static final String MESSAGE_SUCCESS = "Listed all applicants";
+    public static final String MESSAGE_SUCCESS_ALL = "Listed all applicants";
+    public static final String MESSAGE_SUCCESS_FILTER = "Filtered applicants, %1$d applicants listed";
+
+    private FilterType filterType;
+    private FilterArgument filterArgument;
+
+    /**
+     * Creates an ListApplicantCommand to display all {@code Applicant}
+     */
+    public ListApplicantCommand() {
+        filterType = null;
+        filterArgument = null;
+    }
+
+    /**
+     * Creates an ListApplicantCommand to filter and display {@code Applicant}
+     */
+    public ListApplicantCommand(FilterType filterType, FilterArgument filterArgument) {
+        this.filterType = filterType;
+        this.filterArgument = filterArgument;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-        return new CommandResult(MESSAGE_SUCCESS, getCommandDataType());
+        if (filterType != null && filterArgument != null) {
+            String[] nameKeywords = filterArgument.toString().split("\\s+");
+            Predicate<Applicant> predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+            model.updateFilteredApplicantList(predicate);
+            return new CommandResult(
+                    String.format(MESSAGE_SUCCESS_FILTER, model.getFilteredApplicantList().size()),
+                    getCommandDataType());
+        } else {
+            model.updateFilteredApplicantList(PREDICATE_SHOW_ALL_PERSONS);
+            return new CommandResult(MESSAGE_SUCCESS_ALL, getCommandDataType());
+        }
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
@@ -1,6 +1,8 @@
 package seedu.address.logic.commands.applicant;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
 import seedu.address.commons.core.DataType;
@@ -10,7 +12,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.model.Model;
 import seedu.address.model.applicant.Applicant;
-import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+import seedu.address.model.applicant.ApplicantNamePredicate;
 
 import java.util.Arrays;
 import java.util.function.Predicate;
@@ -19,8 +21,17 @@ import java.util.function.Predicate;
  * Lists all persons in the address book to the user.
  */
 public class ListApplicantCommand extends ListCommand {
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " -a: List applicants  with optional parameters."
+            + "\nOptional parameters: "
+            + PREFIX_FILTER_TYPE + "FILTER_TYPE "
+            + PREFIX_FILTER_ARGUMENT + "FILTER_TYPE "
+            + "\nExample: " + COMMAND_WORD + " -a "
+            + PREFIX_FILTER_TYPE + "name "
+            + PREFIX_FILTER_ARGUMENT + "John Doe ";
+
     public static final String MESSAGE_SUCCESS_ALL = "Listed all applicants";
-    public static final String MESSAGE_SUCCESS_FILTER = "Filtered applicants, %1$d applicants listed";
+    public static final String MESSAGE_SUCCESS_FILTER = "Filtered applicants, %1$d applicant(s) listed";
 
     private FilterType filterType;
     private FilterArgument filterArgument;
@@ -46,7 +57,7 @@ public class ListApplicantCommand extends ListCommand {
         requireNonNull(model);
         if (filterType != null && filterArgument != null) {
             String[] nameKeywords = filterArgument.toString().split("\\s+");
-            Predicate<Applicant> predicate = new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords));
+            Predicate<Applicant> predicate = new ApplicantNamePredicate(Arrays.asList(nameKeywords));
             model.updateFilteredApplicantList(predicate);
             return new CommandResult(
                     String.format(MESSAGE_SUCCESS_FILTER, model.getFilteredApplicantList().size()),

--- a/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
@@ -5,6 +5,9 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 
+import java.util.Arrays;
+import java.util.function.Predicate;
+
 import seedu.address.commons.core.DataType;
 import seedu.address.logic.FilterArgument;
 import seedu.address.logic.FilterType;
@@ -13,9 +16,6 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.model.Model;
 import seedu.address.model.applicant.Applicant;
 import seedu.address.model.applicant.ApplicantNamePredicate;
-
-import java.util.Arrays;
-import java.util.function.Predicate;
 
 /**
  * Lists applicants in HireLah to the user.

--- a/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
@@ -18,11 +18,11 @@ import java.util.Arrays;
 import java.util.function.Predicate;
 
 /**
- * Lists all persons in the address book to the user.
+ * Lists applicants in HireLah to the user.
  */
 public class ListApplicantCommand extends ListCommand {
 
-    public static final String MESSAGE_USAGE = COMMAND_WORD + " -a: List applicants  with optional parameters."
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " -a: List applicants with optional parameters."
             + "\nOptional parameters: "
             + PREFIX_FILTER_TYPE + "FILTER_TYPE "
             + PREFIX_FILTER_ARGUMENT + "FILTER_TYPE "
@@ -30,8 +30,7 @@ public class ListApplicantCommand extends ListCommand {
             + PREFIX_FILTER_TYPE + "name "
             + PREFIX_FILTER_ARGUMENT + "John Doe ";
 
-    public static final String MESSAGE_SUCCESS_ALL = "Listed all applicants";
-    public static final String MESSAGE_SUCCESS_FILTER = "Filtered applicants, %1$d applicant(s) listed";
+    public static final String MESSAGE_SUCCESS = "Listed %1$d applicants";
 
     private FilterType filterType;
     private FilterArgument filterArgument;
@@ -55,17 +54,20 @@ public class ListApplicantCommand extends ListCommand {
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
+
         if (filterType != null && filterArgument != null) {
-            String[] nameKeywords = filterArgument.toString().split("\\s+");
-            Predicate<Applicant> predicate = new ApplicantNamePredicate(Arrays.asList(nameKeywords));
-            model.updateFilteredApplicantList(predicate);
-            return new CommandResult(
-                    String.format(MESSAGE_SUCCESS_FILTER, model.getFilteredApplicantList().size()),
-                    getCommandDataType());
+            switch(filterType.filterType) {
+            case "name":
+                String[] nameKeywords = filterArgument.toString().split("\\s+");
+                Predicate<Applicant> predicate = new ApplicantNamePredicate(Arrays.asList(nameKeywords));
+                model.updateFilteredApplicantList(predicate);
+            }
         } else {
             model.updateFilteredApplicantList(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(MESSAGE_SUCCESS_ALL, getCommandDataType());
         }
+
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, model.getFilteredApplicantList().size()), getCommandDataType());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/ListApplicantCommand.java
@@ -56,7 +56,7 @@ public class ListApplicantCommand extends ListCommand {
         requireNonNull(model);
 
         if (filterType != null && filterArgument != null) {
-            if (filterType.filterType.equals("name")) {
+            if (filterType.type.equals("name")) {
                 String[] nameKeywords = filterArgument.toString().split("\\s+");
                 Predicate<Applicant> predicate = new ApplicantNamePredicate(Arrays.asList(nameKeywords));
                 model.updateFilteredApplicantList(predicate);

--- a/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
@@ -1,22 +1,85 @@
 package seedu.address.logic.commands.interview;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
 
 import seedu.address.commons.core.DataType;
+import seedu.address.logic.FilterArgument;
+import seedu.address.logic.FilterType;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.model.Model;
+import seedu.address.model.interview.Interview;
+import seedu.address.model.interview.InterviewApplicantPredicate;
+import seedu.address.model.interview.InterviewDatePredicate;
+import seedu.address.model.interview.InterviewPositionPredicate;
 
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
+/**
+ * Lists interviews in HireLah to the user.
+ */
 public class ListInterviewCommand extends ListCommand {
 
-    public static final String MESSAGE_SUCCESS = "Listed all interviews";
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " -i: List interviews with optional parameters."
+            + "\nOptional parameters: "
+            + PREFIX_FILTER_TYPE + "FILTER_TYPE "
+            + PREFIX_FILTER_ARGUMENT + "FILTER_TYPE "
+            + "\nExample: " + COMMAND_WORD + " -i "
+            + PREFIX_FILTER_TYPE + "name "
+            + PREFIX_FILTER_ARGUMENT + "John Doe ";
+
+    public static final String MESSAGE_SUCCESS = "Listed %1$d interviews";
+
+    private FilterType filterType;
+    private FilterArgument filterArgument;
+
+    /**
+     * Creates an ListInterviewCommand to display all {@code Interview}
+     */
+    public ListInterviewCommand() {
+        filterType = null;
+        filterArgument = null;
+    }
+
+    /**
+     * Creates an ListInterviewCommand to filter and display {@code Interview}
+     */
+    public ListInterviewCommand(FilterType filterType, FilterArgument filterArgument) {
+        this.filterType = filterType;
+        this.filterArgument = filterArgument;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);
-        return new CommandResult(MESSAGE_SUCCESS, getCommandDataType());
+
+        if (filterType != null && filterArgument != null) {
+            if (filterType.filterType.equals("appl")) {
+                String[] applicantNameKeywords = filterArgument.toString().split("\\s+");
+                Predicate<Interview> predicateApplicantName =
+                        new InterviewApplicantPredicate(Arrays.asList(applicantNameKeywords));
+                model.updateFilteredInterviewList(predicateApplicantName);
+            } else if (filterType.filterType.equals("pos")) {
+                String[] positionNameKeywords = filterArgument.toString().split("\\s+");
+                Predicate<Interview> predicatePositionName =
+                        new InterviewPositionPredicate(Arrays.asList(positionNameKeywords));
+                model.updateFilteredInterviewList(predicatePositionName);
+            } else if (filterType.filterType.equals("date")) {
+                Predicate<Interview> predicateDate =
+                        new InterviewDatePredicate(LocalDate.parse(filterArgument.toString()));
+                model.updateFilteredInterviewList(predicateDate);
+            }
+        } else {
+            model.updateFilteredInterviewList(PREDICATE_SHOW_ALL_INTERVIEWS);
+        }
+
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, model.getFilteredInterviewList().size()), getCommandDataType());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
@@ -5,6 +5,10 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_INTERVIEWS;
 
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.function.Predicate;
+
 import seedu.address.commons.core.DataType;
 import seedu.address.logic.FilterArgument;
 import seedu.address.logic.FilterType;
@@ -15,10 +19,6 @@ import seedu.address.model.interview.Interview;
 import seedu.address.model.interview.InterviewApplicantPredicate;
 import seedu.address.model.interview.InterviewDatePredicate;
 import seedu.address.model.interview.InterviewPositionPredicate;
-
-import java.time.LocalDate;
-import java.util.Arrays;
-import java.util.function.Predicate;
 
 /**
  * Lists interviews in HireLah to the user.

--- a/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/ListInterviewCommand.java
@@ -59,17 +59,17 @@ public class ListInterviewCommand extends ListCommand {
         requireNonNull(model);
 
         if (filterType != null && filterArgument != null) {
-            if (filterType.filterType.equals("appl")) {
+            if (filterType.type.equals("appl")) {
                 String[] applicantNameKeywords = filterArgument.toString().split("\\s+");
                 Predicate<Interview> predicateApplicantName =
                         new InterviewApplicantPredicate(Arrays.asList(applicantNameKeywords));
                 model.updateFilteredInterviewList(predicateApplicantName);
-            } else if (filterType.filterType.equals("pos")) {
+            } else if (filterType.type.equals("pos")) {
                 String[] positionNameKeywords = filterArgument.toString().split("\\s+");
                 Predicate<Interview> predicatePositionName =
                         new InterviewPositionPredicate(Arrays.asList(positionNameKeywords));
                 model.updateFilteredInterviewList(predicatePositionName);
-            } else if (filterType.filterType.equals("date")) {
+            } else if (filterType.type.equals("date")) {
                 Predicate<Interview> predicateDate =
                         new InterviewDatePredicate(LocalDate.parse(filterArgument.toString()));
                 model.updateFilteredInterviewList(predicateDate);

--- a/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
@@ -3,8 +3,10 @@ package seedu.address.logic.commands.position;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
-import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POSITIONS;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
 
 import seedu.address.commons.core.DataType;
 import seedu.address.logic.FilterArgument;
@@ -12,13 +14,8 @@ import seedu.address.logic.FilterType;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.model.Model;
-import seedu.address.model.applicant.Applicant;
-import seedu.address.model.applicant.ApplicantNamePredicate;
 import seedu.address.model.position.Position;
 import seedu.address.model.position.PositionNamePredicate;
-
-import java.util.Arrays;
-import java.util.function.Predicate;
 
 /**
  * Lists positions in HireLah to the user.

--- a/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
@@ -1,24 +1,76 @@
 package seedu.address.logic.commands.position;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_POSITIONS;
 
 import seedu.address.commons.core.DataType;
+import seedu.address.logic.FilterArgument;
+import seedu.address.logic.FilterType;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.model.Model;
+import seedu.address.model.applicant.Applicant;
+import seedu.address.model.applicant.ApplicantNamePredicate;
+import seedu.address.model.position.Position;
+import seedu.address.model.position.PositionNamePredicate;
+
+import java.util.Arrays;
+import java.util.function.Predicate;
 
 /**
- * Lists all positions in the address book to the user.
+ * Lists positions in HireLah to the user.
  */
 public class ListPositionCommand extends ListCommand {
-    public static final String MESSAGE_SUCCESS = "Listed all Positions";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD + " -p: List positions with optional parameters."
+            + "\nOptional parameters: "
+            + PREFIX_FILTER_TYPE + "FILTER_TYPE "
+            + PREFIX_FILTER_ARGUMENT + "FILTER_TYPE "
+            + "\nExample: " + COMMAND_WORD + " -p "
+            + PREFIX_FILTER_TYPE + "name "
+            + PREFIX_FILTER_ARGUMENT + "Software Engineer ";
+
+    public static final String MESSAGE_SUCCESS = "Listed %1$d Position(s)";
+
+    private FilterType filterType;
+    private FilterArgument filterArgument;
+
+    /**
+     * Creates an ListPositionCommand to display all {@code Position}
+     */
+    public ListPositionCommand() {
+        filterType = null;
+        filterArgument = null;
+    }
+
+    /**
+     * Creates an ListPositionCommand to filter and display {@code Position}
+     */
+    public ListPositionCommand(FilterType filterType, FilterArgument filterArgument) {
+        this.filterType = filterType;
+        this.filterArgument = filterArgument;
+    }
 
     @Override
     public CommandResult execute(Model model) {
         requireNonNull(model);
-        model.updateFilteredPositionList(PREDICATE_SHOW_ALL_POSITIONS);
-        return new CommandResult(MESSAGE_SUCCESS, getCommandDataType());
+
+        if (filterType != null && filterArgument != null) {
+            switch(filterType.filterType) {
+            case "name":
+                String[] nameKeywords = filterArgument.toString().split("\\s+");
+                Predicate<Position> predicate = new PositionNamePredicate(Arrays.asList(nameKeywords));
+                model.updateFilteredPositionList(predicate);
+            }
+        } else {
+            model.updateFilteredPositionList(PREDICATE_SHOW_ALL_POSITIONS);
+        }
+
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS, model.getFilteredPositionList().size()), getCommandDataType());
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
@@ -33,7 +33,7 @@ public class ListPositionCommand extends ListCommand {
             + PREFIX_FILTER_TYPE + "name "
             + PREFIX_FILTER_ARGUMENT + "Software Engineer ";
 
-    public static final String MESSAGE_SUCCESS = "Listed %1$d Position(s)";
+    public static final String MESSAGE_SUCCESS = "Listed %1$d position(s)";
 
     private FilterType filterType;
     private FilterArgument filterArgument;
@@ -59,8 +59,7 @@ public class ListPositionCommand extends ListCommand {
         requireNonNull(model);
 
         if (filterType != null && filterArgument != null) {
-            switch(filterType.filterType) {
-            case "name":
+            if (filterType.filterType.equals("name")) {
                 String[] nameKeywords = filterArgument.toString().split("\\s+");
                 Predicate<Position> predicate = new PositionNamePredicate(Arrays.asList(nameKeywords));
                 model.updateFilteredPositionList(predicate);

--- a/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/ListPositionCommand.java
@@ -56,7 +56,7 @@ public class ListPositionCommand extends ListCommand {
         requireNonNull(model);
 
         if (filterType != null && filterArgument != null) {
-            if (filterType.filterType.equals("name")) {
+            if (filterType.type.equals("name")) {
                 String[] nameKeywords = filterArgument.toString().split("\\s+");
                 Predicate<Position> predicate = new PositionNamePredicate(Arrays.asList(nameKeywords));
                 model.updateFilteredPositionList(predicate);

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -57,9 +57,6 @@ public class AddressBookParser {
         case ClearCommand.COMMAND_WORD:
             return new ClearCommand();
 
-        case FindCommand.COMMAND_WORD:
-            return new FindCommandParser().parse(arguments);
-
         case ListCommand.COMMAND_WORD:
             return new ListCommandParser().parse(arguments);
 

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,7 +12,6 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.help.HelpCommand;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/main/java/seedu/address/logic/parser/CliSyntax.java
+++ b/src/main/java/seedu/address/logic/parser/CliSyntax.java
@@ -21,4 +21,7 @@ public class CliSyntax {
     public static final Prefix PREFIX_NUM_OPENINGS = new Prefix("o/");
     public static final Prefix PREFIX_DESCRIPTION = new Prefix("d/");
     public static final Prefix PREFIX_REQUIREMENT = new Prefix("r/");
+    // List parser
+    public static final Prefix PREFIX_FILTER_TYPE = new Prefix("f/");
+    public static final Prefix PREFIX_FILTER_ARGUMENT = new Prefix("a/");
 }

--- a/src/main/java/seedu/address/logic/parser/FindCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindCommandParser.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
-import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+import seedu.address.model.applicant.ApplicantNamePredicate;
 
 /**
  * Parses input arguments and creates a new FindCommand object
@@ -27,7 +27,7 @@ public class FindCommandParser implements Parser<FindCommand> {
 
         String[] nameKeywords = trimmedArgs.split("\\s+");
 
-        return new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList(nameKeywords)));
+        return new FindCommand(new ApplicantNamePredicate(Arrays.asList(nameKeywords)));
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.interview.ListInterviewCommand;
 import seedu.address.logic.commands.position.ListPositionCommand;
 import seedu.address.logic.parser.applicants.ListApplicantCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.position.ListPositionCommandParser;
 
 public class ListCommandParser implements Parser<ListCommand> {
 
@@ -28,7 +29,7 @@ public class ListCommandParser implements Parser<ListCommand> {
         } else if (flag == FLAG_INTERVIEW) {
             return new ListInterviewCommand();
         } else if (flag == FLAG_POSITION) {
-            return new ListPositionCommand();
+            return new ListPositionCommandParser().parse(argsWithoutFlag);
         }
 
         return null;

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -8,6 +8,7 @@ import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.applicant.ListApplicantCommand;
 import seedu.address.logic.commands.interview.ListInterviewCommand;
 import seedu.address.logic.commands.position.ListPositionCommand;
+import seedu.address.logic.parser.applicants.ListApplicantCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 public class ListCommandParser implements Parser<ListCommand> {
@@ -20,9 +21,10 @@ public class ListCommandParser implements Parser<ListCommand> {
     @Override
     public ListCommand parse(String args) throws ParseException {
         char flag = ArgumentTokenizer.getFlag(args.trim());
+        String argsWithoutFlag = ArgumentTokenizer.removeFlag(args.trim());
 
         if (flag == FLAG_APPLICANT) {
-            return new ListApplicantCommand();
+            return new ListApplicantCommandParser().parse(argsWithoutFlag);
         } else if (flag == FLAG_INTERVIEW) {
             return new ListInterviewCommand();
         } else if (flag == FLAG_POSITION) {

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -10,6 +10,7 @@ import seedu.address.logic.commands.interview.ListInterviewCommand;
 import seedu.address.logic.commands.position.ListPositionCommand;
 import seedu.address.logic.parser.applicants.ListApplicantCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.logic.parser.interview.ListInterviewCommandParser;
 import seedu.address.logic.parser.position.ListPositionCommandParser;
 
 public class ListCommandParser implements Parser<ListCommand> {
@@ -27,7 +28,7 @@ public class ListCommandParser implements Parser<ListCommand> {
         if (flag == FLAG_APPLICANT) {
             return new ListApplicantCommandParser().parse(argsWithoutFlag);
         } else if (flag == FLAG_INTERVIEW) {
-            return new ListInterviewCommand();
+            return new ListInterviewCommandParser().parse(argsWithoutFlag);
         } else if (flag == FLAG_POSITION) {
             return new ListPositionCommandParser().parse(argsWithoutFlag);
         }

--- a/src/main/java/seedu/address/logic/parser/ListCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ListCommandParser.java
@@ -5,9 +5,6 @@ import static seedu.address.commons.core.DataTypeFlags.FLAG_INTERVIEW;
 import static seedu.address.commons.core.DataTypeFlags.FLAG_POSITION;
 
 import seedu.address.logic.commands.ListCommand;
-import seedu.address.logic.commands.applicant.ListApplicantCommand;
-import seedu.address.logic.commands.interview.ListInterviewCommand;
-import seedu.address.logic.commands.position.ListPositionCommand;
 import seedu.address.logic.parser.applicants.ListApplicantCommandParser;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.logic.parser.interview.ListInterviewCommandParser;

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -10,6 +10,7 @@ import java.util.HashSet;
 import java.util.Set;
 
 import seedu.address.commons.core.DataType;
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
 import seedu.address.logic.FilterArgument;
@@ -181,7 +182,7 @@ public class ParserUtil {
             LocalDateTime dateParsed = LocalDateTime.parse(date, formatter);
             return dateParsed;
         } catch (DateTimeException e) {
-            throw new ParseException("Date time format should be yyyy-MM-dd HH:mm");
+            throw new ParseException(Messages.MESSAGE_INVALID_DATETIME);
         }
 
     }
@@ -276,15 +277,9 @@ public class ParserUtil {
     /**
      * Parses a {@code String filterArgument} into a {@code FilterArgument}.
      * Leading and trailing whitespaces will be trimmed.
-     *
-     * @throws ParseException if the given {@code filterArgument} is invalid.
      */
-    public static FilterArgument parseFilterArgument(String filterArgument) throws ParseException {
+    public static FilterArgument parseFilterArgument(String filterArgument) {
         requireNonNull(filterArgument);
-        String trimmedFilterArgument = filterArgument.trim();
-        if (!FilterArgument.isValidFilterArgument(trimmedFilterArgument)) {
-            throw new ParseException(FilterArgument.MESSAGE_CONSTRAINTS);
-        }
-        return new FilterArgument(trimmedFilterArgument);
+        return new FilterArgument(filterArgument.trim());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -266,7 +266,7 @@ public class ParserUtil {
      */
     public static FilterType parseFilterType(DataType dataType, String filterType) throws ParseException {
         requireNonNull(filterType);
-        String trimmedFilterType = filterType.trim();
+        String trimmedFilterType = filterType.trim().toLowerCase();
         if (!FilterType.isValidFilterType(dataType, trimmedFilterType)) {
             throw new ParseException(FilterType.MESSAGE_CONSTRAINTS);
         }

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -9,8 +9,11 @@ import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
 
+import seedu.address.commons.core.DataType;
 import seedu.address.commons.core.index.Index;
 import seedu.address.commons.util.StringUtil;
+import seedu.address.logic.FilterArgument;
+import seedu.address.logic.FilterType;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.applicant.Address;
 import seedu.address.model.applicant.Age;
@@ -253,5 +256,35 @@ public class ParserUtil {
             requirementSet.add(parseRequirement(requirement));
         }
         return requirementSet;
+    }
+
+    /**
+     * Parses a {@code String filterType} into a {@code FilterType}, along with the corresponding data type.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code filterType} is invalid for the {@code dataType}.
+     */
+    public static FilterType parseFilterType(DataType dataType, String filterType) throws ParseException {
+        requireNonNull(filterType);
+        String trimmedFilterType = filterType.trim();
+        if (!FilterType.isValidFilterType(dataType, trimmedFilterType)) {
+            throw new ParseException(FilterType.MESSAGE_CONSTRAINTS);
+        }
+        return new FilterType(dataType, trimmedFilterType);
+    }
+
+    /**
+     * Parses a {@code String filterArgument} into a {@code FilterArgument}.
+     * Leading and trailing whitespaces will be trimmed.
+     *
+     * @throws ParseException if the given {@code filterArgument} is invalid.
+     */
+    public static FilterArgument parseFilterArgument(String filterArgument) throws ParseException {
+        requireNonNull(filterArgument);
+        String trimmedFilterArgument = filterArgument.trim();
+        if (!FilterArgument.isValidFilterArgument(trimmedFilterArgument)) {
+            throw new ParseException(FilterArgument.MESSAGE_CONSTRAINTS);
+        }
+        return new FilterArgument(trimmedFilterArgument);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/applicants/ListApplicantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/applicants/ListApplicantCommandParser.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.parser.applicants;
 
 import seedu.address.commons.core.DataType;
+import seedu.address.commons.core.Messages;
 import seedu.address.logic.FilterArgument;
 import seedu.address.logic.FilterType;
 import seedu.address.logic.commands.applicant.ListApplicantCommand;
@@ -8,18 +9,12 @@ import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import java.util.stream.Stream;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 
 public class ListApplicantCommandParser implements Parser<ListApplicantCommand> {
-
-    public static final String MESSAGE_FILTER_NO_ARGUMENT = "An argument is required for filter";
 
     /**
      * Parses the given {@code String} of arguments in the context of the ListApplicantCommand
@@ -28,12 +23,6 @@ public class ListApplicantCommandParser implements Parser<ListApplicantCommand> 
      */
     public ListApplicantCommand parse(String args) throws ParseException {
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FILTER_TYPE, PREFIX_FILTER_ARGUMENT);
-
-        /*
-        if (argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddApplicantCommand.MESSAGE_USAGE));
-        }
-        */
 
         if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
                 argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
@@ -47,17 +36,10 @@ public class ListApplicantCommandParser implements Parser<ListApplicantCommand> 
         } else if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
                 !argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
 
-            throw new ParseException(MESSAGE_FILTER_NO_ARGUMENT);
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    ListApplicantCommand.MESSAGE_USAGE));
         } else {
             return new ListApplicantCommand();
         }
-    }
-
-    /**
-     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
-     * {@code ArgumentMultimap}.
-     */
-    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
-        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
     }
 }

--- a/src/main/java/seedu/address/logic/parser/applicants/ListApplicantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/applicants/ListApplicantCommandParser.java
@@ -1,0 +1,63 @@
+package seedu.address.logic.parser.applicants;
+
+import seedu.address.commons.core.DataType;
+import seedu.address.logic.FilterArgument;
+import seedu.address.logic.FilterType;
+import seedu.address.logic.commands.applicant.ListApplicantCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.Prefix;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import java.util.stream.Stream;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+
+public class ListApplicantCommandParser implements Parser<ListApplicantCommand> {
+
+    public static final String MESSAGE_FILTER_NO_ARGUMENT = "An argument is required for filter";
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListApplicantCommand
+     * and returns an ListApplicantCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListApplicantCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FILTER_TYPE, PREFIX_FILTER_ARGUMENT);
+
+        /*
+        if (argMultimap.getPreamble().isEmpty()) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, AddApplicantCommand.MESSAGE_USAGE));
+        }
+        */
+
+        if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
+                argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
+
+            FilterType filterType =
+                    ParserUtil.parseFilterType(DataType.APPLICANT, argMultimap.getValue(PREFIX_FILTER_TYPE).get());
+            FilterArgument filterArgument =
+                    ParserUtil.parseFilterArgument(argMultimap.getValue(PREFIX_FILTER_ARGUMENT).get());
+
+            return new ListApplicantCommand(filterType, filterArgument);
+        } else if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
+                !argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
+
+            throw new ParseException(MESSAGE_FILTER_NO_ARGUMENT);
+        } else {
+            return new ListApplicantCommand();
+        }
+    }
+
+    /**
+     * Returns true if none of the prefixes contains empty {@code Optional} values in the given
+     * {@code ArgumentMultimap}.
+     */
+    private static boolean arePrefixesPresent(ArgumentMultimap argumentMultimap, Prefix... prefixes) {
+        return Stream.of(prefixes).allMatch(prefix -> argumentMultimap.getValue(prefix).isPresent());
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/applicants/ListApplicantCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/applicants/ListApplicantCommandParser.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.parser.applicants;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
+
 import seedu.address.commons.core.DataType;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.FilterArgument;
@@ -10,9 +13,6 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 
 public class ListApplicantCommandParser implements Parser<ListApplicantCommand> {
 
@@ -28,8 +28,8 @@ public class ListApplicantCommandParser implements Parser<ListApplicantCommand> 
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FILTER_TYPE, PREFIX_FILTER_ARGUMENT);
 
-        if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
-                argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
+        if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent()
+                && argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
 
             FilterType filterType =
                     ParserUtil.parseFilterType(DataType.APPLICANT, argMultimap.getValue(PREFIX_FILTER_TYPE).get());

--- a/src/main/java/seedu/address/logic/parser/interview/ListInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/interview/ListInterviewCommandParser.java
@@ -1,5 +1,11 @@
 package seedu.address.logic.parser.interview;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
+
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
 import seedu.address.commons.core.DataType;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.FilterArgument;
@@ -11,12 +17,6 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import java.time.LocalDate;
-import java.time.format.DateTimeParseException;
-
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 
 public class ListInterviewCommandParser implements Parser<ListInterviewCommand> {
     /**
@@ -31,8 +31,8 @@ public class ListInterviewCommandParser implements Parser<ListInterviewCommand> 
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FILTER_TYPE, PREFIX_FILTER_ARGUMENT);
 
-        if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
-                argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
+        if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent()
+                && argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
 
             FilterType filterType =
                     ParserUtil.parseFilterType(DataType.INTERVIEW, argMultimap.getValue(PREFIX_FILTER_TYPE).get());

--- a/src/main/java/seedu/address/logic/parser/interview/ListInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/interview/ListInterviewCommandParser.java
@@ -1,29 +1,32 @@
-package seedu.address.logic.parser.applicants;
+package seedu.address.logic.parser.interview;
 
 import seedu.address.commons.core.DataType;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.FilterArgument;
 import seedu.address.logic.FilterType;
-import seedu.address.logic.commands.applicant.ListApplicantCommand;
+import seedu.address.logic.commands.interview.ListInterviewCommand;
+import seedu.address.logic.commands.position.ListPositionCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 
-public class ListApplicantCommandParser implements Parser<ListApplicantCommand> {
-
+public class ListInterviewCommandParser implements Parser<ListInterviewCommand> {
     /**
-     * Parses the given {@code String} of arguments in the context of the ListApplicantCommand
-     * and returns an ListApplicantCommand object for execution.
+     * Parses the given {@code String} of arguments in the context of the ListInterviewCommand
+     * and returns an ListInterviewCommand object for execution.
      * @throws ParseException if the user input does not conform the expected format
      */
-    public ListApplicantCommand parse(String args) throws ParseException {
+    public ListInterviewCommand parse(String args) throws ParseException {
         if (args.equals("")) {
-            return new ListApplicantCommand();
+            return new ListInterviewCommand();
         }
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FILTER_TYPE, PREFIX_FILTER_ARGUMENT);
@@ -32,14 +35,22 @@ public class ListApplicantCommandParser implements Parser<ListApplicantCommand> 
                 argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
 
             FilterType filterType =
-                    ParserUtil.parseFilterType(DataType.APPLICANT, argMultimap.getValue(PREFIX_FILTER_TYPE).get());
+                    ParserUtil.parseFilterType(DataType.INTERVIEW, argMultimap.getValue(PREFIX_FILTER_TYPE).get());
             FilterArgument filterArgument =
                     ParserUtil.parseFilterArgument(argMultimap.getValue(PREFIX_FILTER_ARGUMENT).get());
 
-            return new ListApplicantCommand(filterType, filterArgument);
+            if (filterType.filterType.equals("date")) {
+                try {
+                    LocalDate.parse(filterArgument.toString());
+                } catch (DateTimeParseException e) {
+                    throw new ParseException(Messages.MESSAGE_INVALID_DATE);
+                }
+            }
+
+            return new ListInterviewCommand(filterType, filterArgument);
         } else {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
-                    ListApplicantCommand.MESSAGE_USAGE));
+                    ListPositionCommand.MESSAGE_USAGE));
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/interview/ListInterviewCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/interview/ListInterviewCommandParser.java
@@ -39,7 +39,7 @@ public class ListInterviewCommandParser implements Parser<ListInterviewCommand> 
             FilterArgument filterArgument =
                     ParserUtil.parseFilterArgument(argMultimap.getValue(PREFIX_FILTER_ARGUMENT).get());
 
-            if (filterType.filterType.equals("date")) {
+            if (filterType.type.equals("date")) {
                 try {
                     LocalDate.parse(filterArgument.toString());
                 } catch (DateTimeParseException e) {

--- a/src/main/java/seedu/address/logic/parser/position/ListPositionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/position/ListPositionCommandParser.java
@@ -1,0 +1,44 @@
+package seedu.address.logic.parser.position;
+
+import seedu.address.commons.core.DataType;
+import seedu.address.commons.core.Messages;
+import seedu.address.logic.FilterArgument;
+import seedu.address.logic.FilterType;
+import seedu.address.logic.commands.position.ListPositionCommand;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.ParserUtil;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
+
+public class ListPositionCommandParser {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the ListPositionCommand
+     * and returns an ListPositionCommand object for execution.
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    public ListPositionCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FILTER_TYPE, PREFIX_FILTER_ARGUMENT);
+
+        if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
+                argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
+
+            FilterType filterType =
+                    ParserUtil.parseFilterType(DataType.POSITION, argMultimap.getValue(PREFIX_FILTER_TYPE).get());
+            FilterArgument filterArgument =
+                    ParserUtil.parseFilterArgument(argMultimap.getValue(PREFIX_FILTER_ARGUMENT).get());
+
+            return new ListPositionCommand(filterType, filterArgument);
+        } else if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
+                !argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
+
+            throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
+                    ListPositionCommand.MESSAGE_USAGE));
+        } else {
+            return new ListPositionCommand();
+        }
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/position/ListPositionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/position/ListPositionCommandParser.java
@@ -7,13 +7,14 @@ import seedu.address.logic.FilterType;
 import seedu.address.logic.commands.position.ListPositionCommand;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.logic.parser.ArgumentTokenizer;
+import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 
-public class ListPositionCommandParser {
+public class ListPositionCommandParser implements Parser<ListPositionCommand> {
 
     /**
      * Parses the given {@code String} of arguments in the context of the ListPositionCommand
@@ -21,6 +22,10 @@ public class ListPositionCommandParser {
      * @throws ParseException if the user input does not conform the expected format
      */
     public ListPositionCommand parse(String args) throws ParseException {
+        if (args.equals("")) {
+            return new ListPositionCommand();
+        }
+
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FILTER_TYPE, PREFIX_FILTER_ARGUMENT);
 
         if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
@@ -32,13 +37,9 @@ public class ListPositionCommandParser {
                     ParserUtil.parseFilterArgument(argMultimap.getValue(PREFIX_FILTER_ARGUMENT).get());
 
             return new ListPositionCommand(filterType, filterArgument);
-        } else if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
-                !argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
-
+        } else {
             throw new ParseException(String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT,
                     ListPositionCommand.MESSAGE_USAGE));
-        } else {
-            return new ListPositionCommand();
         }
     }
 }

--- a/src/main/java/seedu/address/logic/parser/position/ListPositionCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/position/ListPositionCommandParser.java
@@ -1,5 +1,8 @@
 package seedu.address.logic.parser.position;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
+
 import seedu.address.commons.core.DataType;
 import seedu.address.commons.core.Messages;
 import seedu.address.logic.FilterArgument;
@@ -10,9 +13,6 @@ import seedu.address.logic.parser.ArgumentTokenizer;
 import seedu.address.logic.parser.Parser;
 import seedu.address.logic.parser.ParserUtil;
 import seedu.address.logic.parser.exceptions.ParseException;
-
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_ARGUMENT;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_FILTER_TYPE;
 
 public class ListPositionCommandParser implements Parser<ListPositionCommand> {
 
@@ -28,8 +28,8 @@ public class ListPositionCommandParser implements Parser<ListPositionCommand> {
 
         ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_FILTER_TYPE, PREFIX_FILTER_ARGUMENT);
 
-        if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent() &&
-                argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
+        if (argMultimap.getValue(PREFIX_FILTER_TYPE).isPresent()
+                && argMultimap.getValue(PREFIX_FILTER_ARGUMENT).isPresent()) {
 
             FilterType filterType =
                     ParserUtil.parseFilterType(DataType.POSITION, argMultimap.getValue(PREFIX_FILTER_TYPE).get());

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -88,7 +88,7 @@ public interface Model {
      * Updates the filter of the filtered applicant list to filter by the given {@code predicate}.
      * @throws NullPointerException if {@code predicate} is null.
      */
-    void updateFilteredPersonList(Predicate<Applicant> predicate);
+    void updateFilteredApplicantList(Predicate<Applicant> predicate);
 
     /**
      * Returns true if an interview already exists in the address book.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -106,7 +106,7 @@ public class ModelManager implements Model {
     @Override
     public void addPerson(Applicant applicant) {
         addressBook.addApplicant(applicant);
-        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        updateFilteredApplicantList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
     @Override
@@ -169,7 +169,7 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredPersonList(Predicate<Applicant> predicate) {
+    public void updateFilteredApplicantList(Predicate<Applicant> predicate) {
         requireNonNull(predicate);
         filteredApplicants.setPredicate(predicate);
     }

--- a/src/main/java/seedu/address/model/applicant/ApplicantNamePredicate.java
+++ b/src/main/java/seedu/address/model/applicant/ApplicantNamePredicate.java
@@ -8,10 +8,10 @@ import seedu.address.commons.util.StringUtil;
 /**
  * Tests that a {@code Applicant}'s {@code Name} matches any of the keywords given.
  */
-public class NameContainsKeywordsPredicate implements Predicate<Applicant> {
+public class ApplicantNamePredicate implements Predicate<Applicant> {
     private final List<String> keywords;
 
-    public NameContainsKeywordsPredicate(List<String> keywords) {
+    public ApplicantNamePredicate(List<String> keywords) {
         this.keywords = keywords;
     }
 
@@ -24,7 +24,7 @@ public class NameContainsKeywordsPredicate implements Predicate<Applicant> {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
-                && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
+                || (other instanceof ApplicantNamePredicate // instanceof handles nulls
+                && keywords.equals(((ApplicantNamePredicate) other).keywords)); // state check
     }
 }

--- a/src/main/java/seedu/address/model/applicant/NameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/applicant/NameContainsKeywordsPredicate.java
@@ -27,5 +27,4 @@ public class NameContainsKeywordsPredicate implements Predicate<Applicant> {
                 || (other instanceof NameContainsKeywordsPredicate // instanceof handles nulls
                 && keywords.equals(((NameContainsKeywordsPredicate) other).keywords)); // state check
     }
-
 }

--- a/src/main/java/seedu/address/model/interview/InterviewApplicantPredicate.java
+++ b/src/main/java/seedu/address/model/interview/InterviewApplicantPredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.interview;
+
+import seedu.address.commons.util.StringUtil;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Interview}'s {@code Applicant}'s {@code name} matches any of the keywords given.
+ */
+public class InterviewApplicantPredicate implements Predicate<Interview> {
+    private final List<String> keywords;
+
+    public InterviewApplicantPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Interview interview) {
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsWordIgnoreCase(interview.getApplicant().getName().fullName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof InterviewApplicantPredicate // instanceof handles nulls
+                && keywords.equals(((InterviewApplicantPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/interview/InterviewApplicantPredicate.java
+++ b/src/main/java/seedu/address/model/interview/InterviewApplicantPredicate.java
@@ -1,9 +1,9 @@
 package seedu.address.model.interview;
 
-import seedu.address.commons.util.StringUtil;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Interview}'s {@code Applicant}'s {@code name} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/interview/InterviewDatePredicate.java
+++ b/src/main/java/seedu/address/model/interview/InterviewDatePredicate.java
@@ -1,0 +1,28 @@
+package seedu.address.model.interview;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Interview}'s {@code date} matches the given date.
+ */
+public class InterviewDatePredicate implements Predicate<Interview> {
+    private final LocalDate date;
+
+    public InterviewDatePredicate(LocalDate date) {
+        this.date = date;
+    }
+
+    @Override
+    public boolean test(Interview interview) {
+        return date.isEqual(interview.getDate().toLocalDate());
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof InterviewDatePredicate // instanceof handles nulls
+                && date.equals(((InterviewDatePredicate) other).date)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/interview/InterviewDatePredicate.java
+++ b/src/main/java/seedu/address/model/interview/InterviewDatePredicate.java
@@ -1,7 +1,6 @@
 package seedu.address.model.interview;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.function.Predicate;
 
 /**

--- a/src/main/java/seedu/address/model/interview/InterviewPositionPredicate.java
+++ b/src/main/java/seedu/address/model/interview/InterviewPositionPredicate.java
@@ -1,9 +1,9 @@
 package seedu.address.model.interview;
 
-import seedu.address.commons.util.StringUtil;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Interview}'s {@code Position}'s {@code name} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/interview/InterviewPositionPredicate.java
+++ b/src/main/java/seedu/address/model/interview/InterviewPositionPredicate.java
@@ -1,0 +1,32 @@
+package seedu.address.model.interview;
+
+import seedu.address.commons.util.StringUtil;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Interview}'s {@code Position}'s {@code name} matches any of the keywords given.
+ */
+public class InterviewPositionPredicate implements Predicate<Interview> {
+    private final List<String> keywords;
+
+    public InterviewPositionPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Interview interview) {
+        return keywords.stream()
+                .anyMatch(keyword ->
+                        StringUtil.containsWordIgnoreCase(
+                                interview.getPosition().getPositionName().positionName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof InterviewPositionPredicate // instanceof handles nulls
+                && keywords.equals(((InterviewPositionPredicate) other).keywords)); // state check
+    }
+}

--- a/src/main/java/seedu/address/model/position/PositionNamePredicate.java
+++ b/src/main/java/seedu/address/model/position/PositionNamePredicate.java
@@ -1,10 +1,9 @@
 package seedu.address.model.position;
 
-import seedu.address.commons.util.StringUtil;
-import seedu.address.model.applicant.ApplicantNamePredicate;
-
 import java.util.List;
 import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
 
 /**
  * Tests that a {@code Position}'s {@code Name} matches any of the keywords given.

--- a/src/main/java/seedu/address/model/position/PositionNamePredicate.java
+++ b/src/main/java/seedu/address/model/position/PositionNamePredicate.java
@@ -1,0 +1,31 @@
+package seedu.address.model.position;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.model.applicant.ApplicantNamePredicate;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+/**
+ * Tests that a {@code Position}'s {@code Name} matches any of the keywords given.
+ */
+public class PositionNamePredicate implements Predicate<Position> {
+    private final List<String> keywords;
+
+    public PositionNamePredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Position pos) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(pos.getPositionName().positionName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof PositionNamePredicate // instanceof handles nulls
+                && keywords.equals(((PositionNamePredicate) other).keywords)); // state check
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddApplicantCommandTest.java
@@ -159,7 +159,7 @@ public class AddApplicantCommandTest {
         }
 
         @Override
-        public void updateFilteredPersonList(Predicate<Applicant> predicate) {
+        public void updateFilteredApplicantList(Predicate<Applicant> predicate) {
             throw new AssertionError("This method should not be called.");
         }
 

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -25,7 +25,7 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
 import seedu.address.model.applicant.Applicant;
-import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+import seedu.address.model.applicant.ApplicantNamePredicate;
 import seedu.address.testutil.EditApplicantDescriptorBuilder;
 
 /**
@@ -164,7 +164,7 @@ public class CommandTestUtil {
 
         Applicant applicant = model.getFilteredApplicantList().get(targetIndex.getZeroBased());
         final String[] splitName = applicant.getName().fullName.split("\\s+");
-        model.updateFilteredApplicantList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredApplicantList(new ApplicantNamePredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredApplicantList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -164,7 +164,7 @@ public class CommandTestUtil {
 
         Applicant applicant = model.getFilteredApplicantList().get(targetIndex.getZeroBased());
         final String[] splitName = applicant.getName().fullName.split("\\s+");
-        model.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
+        model.updateFilteredApplicantList(new NameContainsKeywordsPredicate(Arrays.asList(splitName[0])));
 
         assertEquals(1, model.getFilteredApplicantList().size());
     }

--- a/src/test/java/seedu/address/logic/commands/DeleteApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteApplicantCommandTest.java
@@ -107,7 +107,7 @@ public class DeleteApplicantCommandTest {
      * Updates {@code model}'s filtered list to show no one.
      */
     private void showNoPerson(Model model) {
-        model.updateFilteredPersonList(p -> false);
+        model.updateFilteredApplicantList(p -> false);
 
         assertTrue(model.getFilteredApplicantList().isEmpty());
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -59,7 +59,7 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
         NameContainsKeywordsPredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredApplicantList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Collections.emptyList(), model.getFilteredApplicantList());
     }
@@ -69,7 +69,7 @@ public class FindCommandTest {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
         NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
-        expectedModel.updateFilteredPersonList(predicate);
+        expectedModel.updateFilteredApplicantList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
         assertEquals(Arrays.asList(CARL, ELLE, FIONA), model.getFilteredApplicantList());
     }

--- a/src/test/java/seedu/address/logic/commands/FindCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FindCommandTest.java
@@ -18,7 +18,7 @@ import org.junit.jupiter.api.Test;
 import seedu.address.model.Model;
 import seedu.address.model.ModelManager;
 import seedu.address.model.UserPrefs;
-import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+import seedu.address.model.applicant.ApplicantNamePredicate;
 
 /**
  * Contains integration tests (interaction with the Model) for {@code FindCommand}.
@@ -29,10 +29,10 @@ public class FindCommandTest {
 
     @Test
     public void equals() {
-        NameContainsKeywordsPredicate firstPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("first"));
-        NameContainsKeywordsPredicate secondPredicate =
-                new NameContainsKeywordsPredicate(Collections.singletonList("second"));
+        ApplicantNamePredicate firstPredicate =
+                new ApplicantNamePredicate(Collections.singletonList("first"));
+        ApplicantNamePredicate secondPredicate =
+                new ApplicantNamePredicate(Collections.singletonList("second"));
 
         FindCommand findFirstCommand = new FindCommand(firstPredicate);
         FindCommand findSecondCommand = new FindCommand(secondPredicate);
@@ -57,7 +57,7 @@ public class FindCommandTest {
     @Test
     public void execute_zeroKeywords_noPersonFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 0);
-        NameContainsKeywordsPredicate predicate = preparePredicate(" ");
+        ApplicantNamePredicate predicate = preparePredicate(" ");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredApplicantList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -67,7 +67,7 @@ public class FindCommandTest {
     @Test
     public void execute_multipleKeywords_multiplePersonsFound() {
         String expectedMessage = String.format(MESSAGE_PERSONS_LISTED_OVERVIEW, 3);
-        NameContainsKeywordsPredicate predicate = preparePredicate("Kurz Elle Kunz");
+        ApplicantNamePredicate predicate = preparePredicate("Kurz Elle Kunz");
         FindCommand command = new FindCommand(predicate);
         expectedModel.updateFilteredApplicantList(predicate);
         assertCommandSuccess(command, model, expectedMessage, expectedModel);
@@ -75,9 +75,9 @@ public class FindCommandTest {
     }
 
     /**
-     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     * Parses {@code userInput} into a {@code ApplicantNamePredicate}.
      */
-    private NameContainsKeywordsPredicate preparePredicate(String userInput) {
-        return new NameContainsKeywordsPredicate(Arrays.asList(userInput.split("\\s+")));
+    private ApplicantNamePredicate preparePredicate(String userInput) {
+        return new ApplicantNamePredicate(Arrays.asList(userInput.split("\\s+")));
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListApplicantCommandTest.java
@@ -26,15 +26,17 @@ public class ListApplicantCommandTest {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
     }
-    
+
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListApplicantCommand(), model, String.format(ListApplicantCommand.MESSAGE_SUCCESS,
+                expectedModel.getFilteredApplicantList().size()), expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListApplicantCommand(), model, String.format(ListApplicantCommand.MESSAGE_SUCCESS,
+                expectedModel.getFilteredApplicantList().size()), expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListApplicantCommandTest.java
@@ -26,7 +26,7 @@ public class ListApplicantCommandTest {
         model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
         expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
     }
-
+    
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
         assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS, expectedModel);

--- a/src/test/java/seedu/address/logic/commands/ListApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListApplicantCommandTest.java
@@ -29,12 +29,12 @@ public class ListApplicantCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS_ALL, expectedModel);
+        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS_ALL, expectedModel);
+        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/ListApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ListApplicantCommandTest.java
@@ -29,12 +29,12 @@ public class ListApplicantCommandTest {
 
     @Test
     public void execute_listIsNotFiltered_showsSameList() {
-        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS_ALL, expectedModel);
     }
 
     @Test
     public void execute_listIsFiltered_showsEverything() {
         showPersonAtIndex(model, INDEX_FIRST_PERSON);
-        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS, expectedModel);
+        assertCommandSuccess(new ListApplicantCommand(), model, ListApplicantCommand.MESSAGE_SUCCESS_ALL, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -25,7 +25,7 @@ import seedu.address.logic.commands.help.HelpCommand;
 import seedu.address.logic.commands.applicant.ListApplicantCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.applicant.Applicant;
-import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+import seedu.address.model.applicant.ApplicantNamePredicate;
 import seedu.address.testutil.EditApplicantDescriptorBuilder;
 import seedu.address.testutil.PersonBuilder;
 import seedu.address.testutil.ApplicantUtil;
@@ -75,7 +75,7 @@ public class AddressBookParserTest {
         List<String> keywords = Arrays.asList("foo", "bar", "baz");
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
-        assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+        assertEquals(new FindCommand(new ApplicantNamePredicate(keywords)), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FindCommandParserTest.java
@@ -9,7 +9,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.commands.FindCommand;
-import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+import seedu.address.model.applicant.ApplicantNamePredicate;
 
 public class FindCommandParserTest {
 
@@ -24,7 +24,7 @@ public class FindCommandParserTest {
     public void parse_validArgs_returnsFindCommand() {
         // no leading and trailing whitespaces
         FindCommand expectedFindCommand =
-                new FindCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
+                new FindCommand(new ApplicantNamePredicate(Arrays.asList("Alice", "Bob")));
         assertParseSuccess(parser, "Alice Bob", expectedFindCommand);
 
         // multiple whitespaces between keywords

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -15,7 +15,7 @@ import java.util.Arrays;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.model.applicant.NameContainsKeywordsPredicate;
+import seedu.address.model.applicant.ApplicantNamePredicate;
 import seedu.address.testutil.AddressBookBuilder;
 
 public class ModelManagerTest {
@@ -118,7 +118,7 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredApplicantList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        modelManager.updateFilteredApplicantList(new ApplicantNamePredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -118,11 +118,11 @@ public class ModelManagerTest {
 
         // different filteredList -> returns false
         String[] keywords = ALICE.getName().fullName.split("\\s+");
-        modelManager.updateFilteredPersonList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
+        modelManager.updateFilteredApplicantList(new NameContainsKeywordsPredicate(Arrays.asList(keywords)));
         assertFalse(modelManager.equals(new ModelManager(addressBook, userPrefs)));
 
         // resets modelManager to initial state for upcoming tests
-        modelManager.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        modelManager.updateFilteredApplicantList(PREDICATE_SHOW_ALL_PERSONS);
 
         // different userPrefs -> returns false
         UserPrefs differentUserPrefs = new UserPrefs();

--- a/src/test/java/seedu/address/model/applicant/ApplicantNamePredicateTest.java
+++ b/src/test/java/seedu/address/model/applicant/ApplicantNamePredicateTest.java
@@ -11,21 +11,21 @@ import org.junit.jupiter.api.Test;
 
 import seedu.address.testutil.PersonBuilder;
 
-public class NameContainsKeywordsPredicateTest {
+public class ApplicantNamePredicateTest {
 
     @Test
     public void equals() {
         List<String> firstPredicateKeywordList = Collections.singletonList("first");
         List<String> secondPredicateKeywordList = Arrays.asList("first", "second");
 
-        NameContainsKeywordsPredicate firstPredicate = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
-        NameContainsKeywordsPredicate secondPredicate = new NameContainsKeywordsPredicate(secondPredicateKeywordList);
+        ApplicantNamePredicate firstPredicate = new ApplicantNamePredicate(firstPredicateKeywordList);
+        ApplicantNamePredicate secondPredicate = new ApplicantNamePredicate(secondPredicateKeywordList);
 
         // same object -> returns true
         assertTrue(firstPredicate.equals(firstPredicate));
 
         // same values -> returns true
-        NameContainsKeywordsPredicate firstPredicateCopy = new NameContainsKeywordsPredicate(firstPredicateKeywordList);
+        ApplicantNamePredicate firstPredicateCopy = new ApplicantNamePredicate(firstPredicateKeywordList);
         assertTrue(firstPredicate.equals(firstPredicateCopy));
 
         // different types -> returns false
@@ -41,34 +41,34 @@ public class NameContainsKeywordsPredicateTest {
     @Test
     public void test_nameContainsKeywords_returnsTrue() {
         // One keyword
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.singletonList("Alice"));
+        ApplicantNamePredicate predicate = new ApplicantNamePredicate(Collections.singletonList("Alice"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Multiple keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob"));
+        predicate = new ApplicantNamePredicate(Arrays.asList("Alice", "Bob"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Only one matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Bob", "Carol"));
+        predicate = new ApplicantNamePredicate(Arrays.asList("Bob", "Carol"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Carol").build()));
 
         // Mixed-case keywords
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("aLIce", "bOB"));
+        predicate = new ApplicantNamePredicate(Arrays.asList("aLIce", "bOB"));
         assertTrue(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
     }
 
     @Test
     public void test_nameDoesNotContainKeywords_returnsFalse() {
         // Zero keywords
-        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Collections.emptyList());
+        ApplicantNamePredicate predicate = new ApplicantNamePredicate(Collections.emptyList());
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").build()));
 
         // Non-matching keyword
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("Carol"));
+        predicate = new ApplicantNamePredicate(Arrays.asList("Carol"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice Bob").build()));
 
         // Keywords match phone, email and address, but does not match name
-        predicate = new NameContainsKeywordsPredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
+        predicate = new ApplicantNamePredicate(Arrays.asList("12345", "alice@email.com", "Main", "Street"));
         assertFalse(predicate.test(new PersonBuilder().withName("Alice").withPhone("12345")
                 .withEmail("alice@email.com").withAddress("Main Street").build()));
     }


### PR DESCRIPTION
The list command now accept optional arguments `FILTER_TYPE` and `FILTER_ARGUMENT`. The syntax for list command is now either `list -X` or `list -X f/FILTER_TYPE a/FILTER_ARGUMENT`. If it is neither of the two, an invalid message will be shown.

Here are the different `FILTER_TYPE` I have implemented so far:
1. Applicants: `name`

2. For positions: `name`

3. For interviews: `appl` for applicant name, `pos` for position name, `date` for interview date 