### PR TITLE
Add support for cascading effects of editing Position and Applicant

### DIFF
--- a/src/main/java/seedu/address/logic/commands/applicant/EditApplicantCommand.java
+++ b/src/main/java/seedu/address/logic/commands/applicant/EditApplicantCommand.java
@@ -91,7 +91,7 @@ public class EditApplicantCommand extends EditCommand {
             throw new CommandException(MESSAGE_DUPLICATE_PERSON);
         }
 
-        model.setPerson(applicantToEdit, editedApplicant);
+        model.updateApplicant(applicantToEdit, editedApplicant);
         model.updateFilteredApplicantList(PREDICATE_SHOW_ALL_PERSONS);
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, editedApplicant), getCommandDataType());
     }

--- a/src/main/java/seedu/address/logic/commands/position/EditPositionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/position/EditPositionCommand.java
@@ -114,7 +114,7 @@ public class EditPositionCommand extends EditCommand {
             throw new CommandException(MESSAGE_DUPLICATE_POSITION);
         }
 
-        model.setPosition(positionToEdit, editedPosition);
+        model.updatePosition(positionToEdit, editedPosition);
         model.updateFilteredPositionList(Model.PREDICATE_SHOW_ALL_POSITIONS);
 
         return new CommandResult(String.format(MESSAGE_EDIT_POSITION_SUCCESS, editedPosition), getCommandDataType());

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -1,6 +1,7 @@
 package seedu.address.model;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.List;
 
@@ -191,6 +192,28 @@ public class AddressBook implements ReadOnlyAddressBook {
      */
     public void removePosition(Position key) {
         positions.remove(key);
+    }
+
+    /**
+     * Updates all old instances of {@code positionToBeUpdated} with {@code newPosition}.
+     * Existence of {@code positionToBeUpdated} and uniqueness of {@code newPosition} will be checked at
+     * {@link #setPosition(Position, Position)}.
+     */
+    public void updatePosition(Position positionToBeUpdated, Position newPosition) {
+        requireAllNonNull(positionToBeUpdated, newPosition);
+        setPosition(positionToBeUpdated, newPosition);
+        interviews.updatePositions(positionToBeUpdated, newPosition);
+    }
+
+    /**
+     * Updates all old instances of {@code applicantToBeUpdated} with {@code newApplicant}.
+     * Existence of {@code applicantToBeUpdated} and uniqueness of {@code newApplicant} will be checked at
+     * {@link #setApplicant(Applicant, Applicant)}.
+     */
+    public void updateApplicant(Applicant applicantToBeUpdated, Applicant newApplicant) {
+        requireAllNonNull(applicantToBeUpdated, newApplicant);
+        setApplicant(applicantToBeUpdated, newApplicant);
+        interviews.updateApplicants(applicantToBeUpdated, newApplicant);
     }
 
     /**

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -161,6 +161,22 @@ public interface Model {
      */
     void setPosition(Position target, Position editedPosition);
 
+    /**
+     * Replaces all instances of {@code positionToBeUpdated} with {@code newPosition}.
+     * {@code positionToBeUpdated} must exist in the address book.
+     * The position identity of {@code newPosition} must not be the same as another existing position
+     * in the address book.
+     */
+    void updatePosition(Position positionToBeUpdated, Position newPosition);
+
+    /**
+     * Replaces all instances of {@code applicantToBeUpdated} with {@code newApplicant}.
+     * {@code applicantToBeUpdated} must exist in the address book.
+     * The applicant identity of {@code newApplicant} must not be the same as another existing applicant
+     * in the address book.
+     */
+    void updateApplicant(Applicant applicantToBeUpdated, Applicant newApplicant);
+
     /** Returns an unmodifiable view of the filtered position list */
     ObservableList<Position> getFilteredPositionList();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -170,6 +170,19 @@ public class ModelManager implements Model {
         addressBook.setPosition(target, editedPosition);
     }
 
+    @Override
+    public void updateApplicant(Applicant applicantToBeUpdated, Applicant newApplicant) {
+        requireAllNonNull(applicantToBeUpdated, newApplicant);
+
+        addressBook.updateApplicant(applicantToBeUpdated, newApplicant);
+    }
+
+    @Override
+    public void updatePosition(Position positionToBeUpdated, Position newPosition) {
+        requireAllNonNull(positionToBeUpdated, newPosition);
+        addressBook.updatePosition(positionToBeUpdated, newPosition);
+    }
+
     //=========== Filtered Applicant List Accessors =============================================================
 
     /**

--- a/src/main/java/seedu/address/model/interview/UniqueInterviewList.java
+++ b/src/main/java/seedu/address/model/interview/UniqueInterviewList.java
@@ -8,8 +8,10 @@ import java.util.List;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
+import seedu.address.model.applicant.Applicant;
 import seedu.address.model.interview.exceptions.DuplicateInterviewException;
 import seedu.address.model.interview.exceptions.InterviewNotFoundException;
+import seedu.address.model.position.Position;
 
 public class UniqueInterviewList implements Iterable<Interview> {
     private final ObservableList<Interview> internalList = FXCollections.observableArrayList();
@@ -95,6 +97,34 @@ public class UniqueInterviewList implements Iterable<Interview> {
         }
 
         internalList.setAll(interview);
+    }
+
+    /**
+     * Updates all interview containing instance of {@code positionToBeUpdated} to {@code newPosition}.
+     * Effects of editing a Position cascades to update all instances of the old position to the edited position.
+     */
+    public void updatePositions(Position positionToBeUpdated, Position newPosition) {
+        requireAllNonNull(positionToBeUpdated, newPosition);
+        for (int i = 0; i < internalList.size(); i++) {
+            Interview curr = internalList.get(i);
+            if (curr.getPosition().equals(positionToBeUpdated)) {
+                internalList.set(i, new Interview(curr.getApplicant(), curr.getDate(), newPosition));
+            }
+        }
+    }
+
+    /**
+     * Updates all interview containing instance of {@code applicantToBeUpdated} to {@code newApplicant}.
+     * Effects of editing an Applicant cascades to update all instances of the old applicant to the edited applicant.
+     */
+    public void updateApplicants(Applicant applicantToBeUpdated, Applicant newApplicant) {
+        requireAllNonNull(applicantToBeUpdated, newApplicant);
+        for (int i = 0; i < internalList.size(); i++) {
+            Interview curr = internalList.get(i);
+            if (curr.getApplicant().equals(applicantToBeUpdated)) {
+                internalList.set(i, new Interview(newApplicant, curr.getDate(), curr.getPosition()));
+            }
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/applicant/AddApplicantCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/applicant/AddApplicantCommandTest.java
@@ -204,6 +204,16 @@ public class AddApplicantCommandTest {
         }
 
         @Override
+        public void updatePosition(Position positionToBeUpdated, Position newPosition) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public void updateApplicant(Applicant applicantToBeUpdated, Applicant newApplicant) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void addPosition(Position position) {
             throw new AssertionError("This method should not be called.");
         }


### PR DESCRIPTION
Issue #162 

The old and new instances of Position and Applicant will be passed to
AddressBook, and all exisiting Interviews that reference the old
Position or Applicant will be updated to reference the new Position
or Applicant respectively.