### PR TITLE
Press up/down arrows to get previous commands

### DIFF
--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -1,8 +1,12 @@
 package seedu.address.ui;
 
+import java.util.ArrayList;
+
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.TextField;
+import javafx.scene.input.KeyCode;
+import javafx.scene.input.KeyEvent;
 import javafx.scene.layout.Region;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -17,6 +21,8 @@ public class CommandBox extends UiPart<Region> {
     private static final String FXML = "CommandBox.fxml";
 
     private final CommandExecutor commandExecutor;
+    private ArrayList<String> previousCommands;
+    private int commandIndex;
 
     @FXML
     private TextField commandTextField;
@@ -29,6 +35,29 @@ public class CommandBox extends UiPart<Region> {
         this.commandExecutor = commandExecutor;
         // calls #setStyleToDefault() whenever there is a change to the text of the command box.
         commandTextField.textProperty().addListener((unused1, unused2, unused3) -> setStyleToDefault());
+        commandTextField.setOnKeyPressed(this::handleKeyPressed);
+
+        previousCommands = new ArrayList<>();
+        commandIndex = -1;
+    }
+
+    /**
+     * Handles the event when a key is pressed.
+     */
+    private void handleKeyPressed(KeyEvent keyEvent) {
+        if (keyEvent.getCode() == KeyCode.UP && commandIndex >= 0) {
+            commandTextField.setText(previousCommands.get(commandIndex));
+            if (commandIndex > 0) {
+                commandIndex--;
+            }
+        } else if (keyEvent.getCode() == KeyCode.DOWN && commandIndex < previousCommands.size()) {
+            if (commandIndex == previousCommands.size() - 1) {
+                commandTextField.setText("");
+            } else {
+                commandIndex++;
+                commandTextField.setText(previousCommands.get(commandIndex));
+            }
+        }
     }
 
     /**
@@ -37,6 +66,7 @@ public class CommandBox extends UiPart<Region> {
     @FXML
     private void handleCommandEntered() {
         String commandText = commandTextField.getText();
+
         if (commandText.equals("")) {
             return;
         }
@@ -44,6 +74,9 @@ public class CommandBox extends UiPart<Region> {
         try {
             commandExecutor.execute(commandText);
             commandTextField.setText("");
+
+            previousCommands.add(commandText);
+            commandIndex = previousCommands.size() - 1;
         } catch (CommandException | ParseException e) {
             setStyleToIndicateCommandFailure();
         }

--- a/src/main/java/seedu/address/ui/CommandBox.java
+++ b/src/main/java/seedu/address/ui/CommandBox.java
@@ -47,6 +47,7 @@ public class CommandBox extends UiPart<Region> {
     private void handleKeyPressed(KeyEvent keyEvent) {
         if (keyEvent.getCode() == KeyCode.UP && commandIndex >= 0) {
             commandTextField.setText(previousCommands.get(commandIndex));
+            commandTextField.positionCaret(commandTextField.getText().length());
             if (commandIndex > 0) {
                 commandIndex--;
             }
@@ -56,6 +57,7 @@ public class CommandBox extends UiPart<Region> {
             } else {
                 commandIndex++;
                 commandTextField.setText(previousCommands.get(commandIndex));
+                commandTextField.positionCaret(commandTextField.getText().length());
             }
         }
     }


### PR DESCRIPTION
I have added support for accessing previously entered commands using up/down arrows. Some notes about the behaviour: 
- All commands from the session will be saved, and discarded after the app exits
- Will only save successful commands, wrong commands will not be cleared from the text box
- Multiple same (successful) commands in a row will all be saved, so need click up a few times