### PR TITLE
Update storage for interview to include composition

### DIFF
--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -277,4 +277,12 @@ public class AddressBook implements ReadOnlyAddressBook {
     public int hashCode() {
         return applicants.hashCode();
     }
+
+    public Applicant getApplicantUsingStorage(Applicant interviewApplicant) {
+        return applicants.getApplicant(interviewApplicant);
+    }
+
+    public Position getPositionUsingStorage(Position interviewPosition) {
+        return positions.getPosition(interviewPosition);
+    }
 }

--- a/src/main/java/seedu/address/model/applicant/UniqueApplicantList.java
+++ b/src/main/java/seedu/address/model/applicant/UniqueApplicantList.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -133,5 +134,10 @@ public class UniqueApplicantList implements Iterable<Applicant> {
             }
         }
         return true;
+    }
+    // May change isSameApplicant to equals if required
+    public Applicant getApplicant(Applicant interviewApplicant) {
+        return internalList.stream().filter(a -> a.isSamePerson(interviewApplicant))
+                        .collect(Collectors.toList()).get(0);
     }
 }

--- a/src/main/java/seedu/address/model/interview/Interview.java
+++ b/src/main/java/seedu/address/model/interview/Interview.java
@@ -15,9 +15,9 @@ import seedu.address.model.position.Position;
 public class Interview {
 
     //Data fields
-    private final Applicant applicant;
+    private Applicant applicant;
     private final LocalDateTime date;
-    private final Position position;
+    private Position position;
     private final Status status;
 
     /**
@@ -45,6 +45,14 @@ public class Interview {
 
     public Status getStatus() {
         return status;
+    }
+
+    public void setApplicant(Applicant applicant) {
+        this.applicant = applicant;
+    }
+
+    public void setPosition(Position position) {
+        this.position = position;
     }
 
     /**

--- a/src/main/java/seedu/address/model/position/UniquePositionList.java
+++ b/src/main/java/seedu/address/model/position/UniquePositionList.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Iterator;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
@@ -135,5 +136,10 @@ public class UniquePositionList implements Iterable<Position> {
             }
         }
         return true;
+    }
+    // May change isSamePosition to equals if required
+    public Position getPosition(Position interviewPosition) {
+        return internalList.stream().filter(a -> a.isSamePosition(interviewPosition))
+                .collect(Collectors.toList()).get(0);
     }
 }

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -2,12 +2,14 @@ package seedu.address.storage;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
+import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -69,14 +71,6 @@ class JsonSerializableAddressBook {
             addressBook.addApplicant(applicant);
         }
 
-        for (JsonAdaptedInterview jsonAdaptedInterview : interviews) {
-            Interview interview = jsonAdaptedInterview.toModelType();
-            if (addressBook.hasInterview(interview)) {
-                throw new IllegalValueException(MESSAGE_DUPLICATE_INTERVIEW);
-            }
-            addressBook.addInterview(interview);
-        }
-
         for (JsonAdaptedPosition jsonAdaptedPosition : positions) {
             Position position = jsonAdaptedPosition.toModelType();
             if (addressBook.hasPosition(position)) {
@@ -84,6 +78,26 @@ class JsonSerializableAddressBook {
             }
             addressBook.addPosition(position);
         }
+
+        for (JsonAdaptedInterview jsonAdaptedInterview : interviews) {
+            Interview interview = jsonAdaptedInterview.toModelType();
+            Applicant interviewApplicant = interview.getApplicant();
+            Position interviewPosition = interview.getPosition();
+
+            if (addressBook.hasApplicant(interviewApplicant)) {
+                interview.setApplicant(addressBook.getApplicantUsingStorage(interviewApplicant));
+            }
+
+            if (addressBook.hasPosition(interviewPosition)) {
+                interview.setPosition(addressBook.getPositionUsingStorage(interviewPosition));
+            }
+
+            if (addressBook.hasInterview(interview)) {
+                throw new IllegalValueException(MESSAGE_DUPLICATE_INTERVIEW);
+            }
+            addressBook.addInterview(interview);
+        }
+
         return addressBook;
     }
 

--- a/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
+++ b/src/main/java/seedu/address/storage/JsonSerializableAddressBook.java
@@ -2,14 +2,12 @@ package seedu.address.storage;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonRootName;
 
-import seedu.address.commons.core.LogsCenter;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.AddressBook;
 import seedu.address.model.ReadOnlyAddressBook;


### PR DESCRIPTION
As we need to cascade the update of applicant and position to interview,
there is a need to create composition when loading from JSON file

Right now, interview has include the applicant and position reference.
But this is base on isSameX method not equals. If in the future need to
change then can change