### PR TITLE
Make status badge stay on top when resizing window

### DIFF
--- a/src/main/resources/view/ApplicantListCard.fxml
+++ b/src/main/resources/view/ApplicantListCard.fxml
@@ -7,7 +7,6 @@
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.Region?>
-<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.layout.VBox?>
 
 <?import javafx.scene.layout.BorderPane?>
@@ -17,7 +16,7 @@
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
       <BorderPane>
-      <left>
+      <center>
     <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
       <padding>
         <Insets bottom="10" left="15" right="5" top="10" />
@@ -32,28 +31,23 @@
         <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
       </HBox>
       <FlowPane fx:id="tags" prefWidth="320"/>
-         <HBox alignment="CENTER_LEFT" spacing="20">
-            <children>
-               <Label fx:id="gender" styleClass="cell_small_label" text="\$gender" />
-               <Label fx:id="age" styleClass="cell_small_label" text="\$age" />
-            </children>
-         </HBox>
+        <HBox alignment="CENTER_LEFT" spacing="20">
+            <Label fx:id="gender" styleClass="cell_small_label" text="\$gender"/>
+            <Label fx:id="age" styleClass="cell_small_label" text="\$age"/>
+        </HBox>
       <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
         <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
         <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
     </VBox>
-      </left>
+      </center>
           <right>
               <VBox alignment="TOP_RIGHT" >
                   <padding>
-                      <Insets bottom="10" left="15" right="15" top="15" />
+                      <Insets bottom="10" left="5" right="15" top="15" />
                   </padding>
                   <Label fx:id="applicantstatus" styleClass="cell_small_label" text="\$status"/>
               </VBox>
           </right>
       </BorderPane>
-      <rowConstraints>
-         <RowConstraints />
-      </rowConstraints>
   </GridPane>
 </HBox>

--- a/src/main/resources/view/InterviewListCard.fxml
+++ b/src/main/resources/view/InterviewListCard.fxml
@@ -39,7 +39,7 @@
           <right>
               <VBox alignment="TOP_RIGHT" >
                   <padding>
-                      <Insets bottom="10" left="15" right="15" top="15" />
+                      <Insets bottom="10" left="5" right="15" top="15" />
                   </padding>
                     <Label fx:id="interviewstatus" styleClass="cell_small_label" text="\$status"/>
               </VBox>


### PR DESCRIPTION
Fixes #214 

The status badge of applicant and interview will not be pushed to the side when the name is really long and the window is resized. The name will be truncated instead when resizing the window
<img width="412" alt="image" src="https://user-images.githubusercontent.com/68813082/161568125-eb98d2ef-2ca0-4eb6-8ee4-27cd635fe3f4.png">
