### PR TITLE
Fix handling of blank filter argument

### DIFF
--- a/src/main/java/seedu/address/logic/FilterArgument.java
+++ b/src/main/java/seedu/address/logic/FilterArgument.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.commons.util.AppUtil.checkArgument;
 
 public class FilterArgument {
 
@@ -15,6 +16,7 @@ public class FilterArgument {
      */
     public FilterArgument(String argument) {
         requireNonNull(argument);
+        checkArgument(argument.isEmpty(), MESSAGE_CONSTRAINTS);
         this.argument = argument;
     }
 

--- a/src/main/java/seedu/address/logic/FilterArgument.java
+++ b/src/main/java/seedu/address/logic/FilterArgument.java
@@ -16,7 +16,7 @@ public class FilterArgument {
      */
     public FilterArgument(String argument) {
         requireNonNull(argument);
-        checkArgument(argument.isEmpty(), MESSAGE_CONSTRAINTS);
+        checkArgument(!argument.isEmpty(), MESSAGE_CONSTRAINTS);
         this.argument = argument;
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -279,8 +279,11 @@ public class ParserUtil {
      * Parses a {@code String filterArgument} into a {@code FilterArgument}.
      * Leading and trailing whitespaces will be trimmed.
      */
-    public static FilterArgument parseFilterArgument(String filterArgument) {
+    public static FilterArgument parseFilterArgument(String filterArgument) throws ParseException {
         requireNonNull(filterArgument);
+        if (filterArgument.trim().isEmpty()) {
+            throw new ParseException(FilterArgument.MESSAGE_CONSTRAINTS);
+        }
         return new FilterArgument(filterArgument.trim());
     }
 


### PR DESCRIPTION
Fix #231 

Added additional check to ensure that blank (including all spaces) filter argument is handled properly.

<img width="440" alt="image" src="https://user-images.githubusercontent.com/68813082/161587928-974397bc-8b17-4362-b559-f9a6c6450bc3.png">
