### PR TITLE
Make command result text box wrap instead of scroll bar

### DIFF
--- a/src/main/resources/view/ResultDisplay.fxml
+++ b/src/main/resources/view/ResultDisplay.fxml
@@ -5,5 +5,5 @@
 
 <StackPane fx:id="placeHolder" styleClass="pane-with-border" xmlns="http://javafx.com/javafx/8"
     xmlns:fx="http://javafx.com/fxml/1">
-  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display"/>
+  <TextArea fx:id="resultDisplay" editable="false" styleClass="result-display" wrapText="true"/>
 </StackPane>


### PR DESCRIPTION
Fix #248 
The text in the command result box will wrap instead of needing horizontal scroll

<img width="678" alt="image" src="https://user-images.githubusercontent.com/68813082/161589457-1d350eae-a016-411e-b617-f714d6ee7128.png">
