### PR TITLE
Refactor interview commands to use interview level methods

### DIFF
--- a/src/main/java/seedu/address/commons/core/Messages.java
+++ b/src/main/java/seedu/address/commons/core/Messages.java
@@ -15,11 +15,9 @@ public class Messages {
     public static final String MESSAGE_INVALID_FLAG = "Flag is invalid!";
     public static final String MESSAGE_NO_FLAG = "No flag is found!";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
-    public static final String MESSAGE_INTERVIEW_CANNOT_BE_PASSED = "The interview cannot be passed, "
-            + "as the number of current offers will exceed the number of available positions or because only pending"
-            + " interviews can be passed";
-    public static final String MESSAGE_INTERVIEW_CANNOT_BE_FAILED = "The interview cannot be failed, "
-            + "because only pending interviews can be failed";
-    public static final String MESSAGE_INTERVIEW_CANNOT_BE_ACCEPTED = "Only passed interviews can be accepted!";
-    public static final String MESSAGE_INTERVIEW_CANNOT_BE_REJECTED = "Only passed interviews can be rejected!";
+    public static final String MESSAGE_DUPLICATE_INTERVIEW = "This interview already exists in the address book";
+    public static final String MESSAGE_CONFLICTING_INTERVIEW = "This interview would cause a conflict of timings with"
+            + " a current interview in the address book. Interviews must be "
+            + "at least 1 hour apart for the same candidate.";
+    public static final String MESSAGE_APPLICANT_SAME_POSITION = "%1$s already has an interview for %2$s";
 }

--- a/src/main/java/seedu/address/logic/commands/interview/AcceptInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/AcceptInterviewCommand.java
@@ -23,6 +23,7 @@ public class AcceptInterviewCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_ACCEPT_INTERVIEW_SUCCESS = "Accept Interview: %1$s";
+    public static final String MESSAGE_INTERVIEW_CANNOT_BE_ACCEPTED = "Only passed interviews can be accepted!";
 
     private final Index targetIndex;
 
@@ -34,30 +35,26 @@ public class AcceptInterviewCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Interview> lastShownList = model.getFilteredInterviewList();
-
         if (targetIndex.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_INTERVIEW_DISPLAYED_INDEX);
         }
 
         Interview interviewToAccept = lastShownList.get(targetIndex.getZeroBased());
-
-        if (!model.isAcceptableInterview(interviewToAccept)) {
-            throw new CommandException(Messages.MESSAGE_INTERVIEW_CANNOT_BE_ACCEPTED);
+        if (!interviewToAccept.isAcceptableInterview()) {
+            throw new CommandException(MESSAGE_INTERVIEW_CANNOT_BE_ACCEPTED);
         }
 
-        // Should this be extracted out to a method
         Position oldPosition = interviewToAccept.getPosition();
         Position newPosition = interviewToAccept.getPosition().acceptOffer();
-
         Applicant oldApplicant = interviewToAccept.getApplicant();
         Applicant newApplicant = interviewToAccept.getApplicant().setStatus(oldApplicant, newPosition);
-
         Interview acceptedInterview = new Interview(newApplicant, interviewToAccept.getDate(),
                 newPosition);
 
-        // Should I change the constructor (of interview) or leave as a method instead
+        // Interview has default status of "Pending", need to make it passed and then accepted
         acceptedInterview.markAsPassed();
         acceptedInterview.markAsAccepted();
+
         model.setInterview(interviewToAccept, acceptedInterview);
         model.updateApplicant(oldApplicant, newApplicant);
         model.updatePosition(oldPosition, newPosition);

--- a/src/main/java/seedu/address/logic/commands/interview/AddInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/AddInterviewCommand.java
@@ -28,11 +28,6 @@ public class AddInterviewCommand extends AddCommand {
             + PREFIX_POSITION + "1";
 
     public static final String MESSAGE_SUCCESS = "New interview added: %1$s";
-    public static final String MESSAGE_DUPLICATE_INTERVIEW = "This interview already exists in the address book";
-    public static final String MESSAGE_CONFLICTING_INTERVIEW = "This interview would cause a conflict of timings with"
-            + " a current interview in the address book. Interviews must be "
-            + "at least 1 hour apart for the same candidate.";
-    public static final String MESSAGE_APPLICANT_SAME_POSITION = "%1$s already has an interview for %2$s";
 
     private final Index applicantIndex;
     private final LocalDateTime date;
@@ -54,10 +49,10 @@ public class AddInterviewCommand extends AddCommand {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         List<Applicant> lastShownApplicantList = model.getFilteredApplicantList();
+
         if (applicantIndex.getZeroBased() >= lastShownApplicantList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX);
         }
-
         Applicant applicantInInterview = lastShownApplicantList.get(applicantIndex.getZeroBased());
 
         List<Position> lastShownPositionList = model.getFilteredPositionList();
@@ -66,22 +61,15 @@ public class AddInterviewCommand extends AddCommand {
         }
 
         Position positionInInterview = lastShownPositionList.get(positionIndex.getZeroBased());
-
         if (model.isSameApplicantPosition(applicantInInterview, positionInInterview)) {
-            throw new CommandException(String.format(MESSAGE_APPLICANT_SAME_POSITION,
+            throw new CommandException(String.format(Messages.MESSAGE_APPLICANT_SAME_POSITION,
                     applicantInInterview.getName().fullName, positionInInterview.getPositionName().positionName));
         }
 
         Interview interviewToAdd = new Interview(applicantInInterview, date, positionInInterview);
-
         if (model.hasConflictingInterview(interviewToAdd)) {
-            throw new CommandException(MESSAGE_CONFLICTING_INTERVIEW);
+            throw new CommandException(Messages.MESSAGE_CONFLICTING_INTERVIEW);
         }
-
-        if (model.hasInterview(interviewToAdd)) {
-            throw new CommandException(MESSAGE_DUPLICATE_INTERVIEW);
-        }
-
         model.addInterview(interviewToAdd);
         return new CommandResult(String.format(MESSAGE_SUCCESS, interviewToAdd), getCommandDataType());
     }

--- a/src/main/java/seedu/address/logic/commands/interview/EditInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/EditInterviewCommand.java
@@ -37,12 +37,7 @@ public class EditInterviewCommand extends EditCommand {
             + PREFIX_POSITION + "2";
 
     public static final String MESSAGE_NOT_EDITED = "At least one field in Interview to edit must be provided.";
-    public static final String MESSAGE_DUPLICATE_INTERVIEW = "This interview already exists in HireLah.";
     public static final String MESSAGE_EDIT_INTERVIEW_SUCCESS = "Edited interview: %1$s";
-    public static final String MESSAGE_CONFLICTING_INTERVIEW = "This interview would cause a conflict of timings with"
-            + " a current interview in the address book. Interviews must be "
-            + "at least 1 hour apart for the same candidate.";
-    public static final String MESSAGE_APPLICANT_SAME_POSITION = "%1$s already has an interview for %2$s.";
     public static final String MESSAGE_NOT_PENDING = "Only interviews that are pending can be edited.";
 
     private final Index index;
@@ -121,18 +116,18 @@ public class EditInterviewCommand extends EditCommand {
 
         if ((applicantEdited || positionEdited)
                 && model.isSameApplicantPosition(editedInterview.getApplicant(), editedInterview.getPosition())) {
-            throw new CommandException(String.format(MESSAGE_APPLICANT_SAME_POSITION,
+            throw new CommandException(String.format(Messages.MESSAGE_APPLICANT_SAME_POSITION,
                     editedInterview.getApplicant().getName().fullName,
                     editedInterview.getPosition().getPositionName().positionName));
         }
 
         boolean dateEdited = !(interviewToEdit.getDate().equals(editedInterview.getDate()));
         if (dateEdited && model.hasConflictingInterview(editedInterview)) {
-            throw new CommandException(MESSAGE_CONFLICTING_INTERVIEW);
+            throw new CommandException(Messages.MESSAGE_CONFLICTING_INTERVIEW);
         }
 
         if (!interviewToEdit.equals(editedInterview) && model.hasInterview(editedInterview)) {
-            throw new CommandException(MESSAGE_DUPLICATE_INTERVIEW);
+            throw new CommandException(Messages.MESSAGE_DUPLICATE_INTERVIEW);
         }
 
         model.setInterview(interviewToEdit, editedInterview);

--- a/src/main/java/seedu/address/logic/commands/interview/FailInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/FailInterviewCommand.java
@@ -21,6 +21,8 @@ public class FailInterviewCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_FAIL_INTERVIEW_SUCCESS = "Failed Interview: %1$s";
+    public static final String MESSAGE_INTERVIEW_CANNOT_BE_FAILED = "The interview cannot be failed, "
+            + "because only pending interviews can be failed";
 
     private final Index targetIndex;
 
@@ -38,9 +40,8 @@ public class FailInterviewCommand extends Command {
         }
 
         Interview interviewToFail = lastShownList.get(targetIndex.getZeroBased());
-
         if (!interviewToFail.isFailableInterview()) {
-            throw new CommandException(Messages.MESSAGE_INTERVIEW_CANNOT_BE_FAILED);
+            throw new CommandException(MESSAGE_INTERVIEW_CANNOT_BE_FAILED);
         }
 
         Interview failedInterview = new Interview(interviewToFail.getApplicant(), interviewToFail.getDate(),

--- a/src/main/java/seedu/address/logic/commands/interview/PassInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/PassInterviewCommand.java
@@ -22,6 +22,9 @@ public class PassInterviewCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_PASS_INTERVIEW_SUCCESS = "Passed Interview: %1$s";
+    public static final String MESSAGE_INTERVIEW_CANNOT_BE_PASSED = "The interview cannot be passed, "
+            + "as the number of current offers will exceed the number of available positions or because only pending"
+            + " interviews can be passed";
 
     private final Index targetIndex;
 
@@ -40,17 +43,15 @@ public class PassInterviewCommand extends Command {
 
         Interview interviewToPass = lastShownList.get(targetIndex.getZeroBased());
 
-        if (!model.isPassableInterview(interviewToPass)) {
-            throw new CommandException(Messages.MESSAGE_INTERVIEW_CANNOT_BE_PASSED);
+        if (!interviewToPass.isPassableInterview()) {
+            throw new CommandException(MESSAGE_INTERVIEW_CANNOT_BE_PASSED);
         }
 
-        // Should this be extracted out to a method
         Position oldPosition = interviewToPass.getPosition();
         Position newPosition = interviewToPass.getPosition().extendOffer();
         Interview passedInterview = new Interview(interviewToPass.getApplicant(), interviewToPass.getDate(),
                 newPosition);
 
-        // Should I change the constructor (of interview) or leave as a method instead
         passedInterview.markAsPassed();
         model.setInterview(interviewToPass, passedInterview);
         model.updatePosition(oldPosition, newPosition);

--- a/src/main/java/seedu/address/logic/commands/interview/RejectInterviewCommand.java
+++ b/src/main/java/seedu/address/logic/commands/interview/RejectInterviewCommand.java
@@ -22,6 +22,7 @@ public class RejectInterviewCommand extends Command {
             + "Example: " + COMMAND_WORD + " 1";
 
     public static final String MESSAGE_REJECT_INTERVIEW_SUCCESS = "Rejected Interview: %1$s";
+    public static final String MESSAGE_INTERVIEW_CANNOT_BE_REJECTED = "Only passed interviews can be rejected!";
 
     private final Index targetIndex;
 
@@ -40,14 +41,12 @@ public class RejectInterviewCommand extends Command {
 
         Interview interviewToReject = lastShownList.get(targetIndex.getZeroBased());
 
-        if (!model.isRejectableInterview(interviewToReject)) {
-            throw new CommandException(Messages.MESSAGE_INTERVIEW_CANNOT_BE_REJECTED);
+        if (!interviewToReject.isRejectableInterview()) {
+            throw new CommandException(MESSAGE_INTERVIEW_CANNOT_BE_REJECTED);
         }
 
-        // Should this be extracted out to a method
         Position oldPosition = interviewToReject.getPosition();
         Position newPosition = interviewToReject.getPosition().rejectOffer();
-
         Interview rejectedInterview = new Interview(interviewToReject.getApplicant(), interviewToReject.getDate(),
                 newPosition);
 

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -167,29 +167,6 @@ public class AddressBook implements ReadOnlyAddressBook {
         return interviews.containsConflict(i);
     }
 
-    /**
-     * Returns true if an interview is passable based on the number of extended offers and openings.
-     */
-    public boolean isPassableInterview(Interview i) {
-        requireNonNull(i);
-        return interviews.isPassableInterview(i);
-    }
-
-    /**
-     * Returns true if an interview is acceptable based on the status of the interview.
-     */
-    public boolean isAcceptableInterview(Interview i) {
-        requireNonNull(i);
-        return interviews.isAcceptableInterview(i);
-    }
-
-    /**
-     * Returns true if an interview is rejectable based on the status of the interview.
-     */
-    public boolean isRejectableInterview(Interview i) {
-        requireNonNull(i);
-        return interviews.isRejectableInterview(i);
-    }
 
     /**
      * Removes {@code key} from this {@code AddressBook}.

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -116,21 +116,6 @@ public interface Model {
     boolean hasConflictingInterview(Interview interview);
 
     /**
-     * Returns true if an interview can be passed.
-     */
-    boolean isPassableInterview(Interview interview);
-
-    /**
-     * Returns true if an interview can be rejected.
-     */
-    boolean isRejectableInterview(Interview interview);
-
-    /**
-     * Returns true if an interview can be accepted.
-     */
-    boolean isAcceptableInterview(Interview interview);
-
-    /**
      * Deletes the given interview.
      * The interview must exist in the address book.
      */

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -155,23 +155,6 @@ public class ModelManager implements Model {
         return addressBook.hasConflictingInterview(interview);
     }
 
-    @Override
-    public boolean isPassableInterview(Interview interview) {
-        requireAllNonNull(interview);
-        return addressBook.isPassableInterview(interview);
-    }
-
-    @Override
-    public boolean isAcceptableInterview(Interview interview) {
-        requireAllNonNull(interview);
-        return addressBook.isAcceptableInterview(interview);
-    }
-
-    @Override
-    public boolean isRejectableInterview(Interview interview) {
-        requireAllNonNull(interview);
-        return addressBook.isRejectableInterview(interview);
-    }
 
     @Override
     public void deleteInterview(Interview target) {

--- a/src/main/java/seedu/address/model/interview/Status.java
+++ b/src/main/java/seedu/address/model/interview/Status.java
@@ -42,7 +42,7 @@ public class Status {
      * Marks an interview as rejected only if status is passed.
      */
     public void markAsRejected() {
-        // Defensive programming to prevent acceptance before passing interview
+        // Defensive programming to prevent rejecting before passing interview
         if (!isPassedStatus()) {
             throw new RuntimeException("The Interview should be passed before its can be accepted by candidate");
         }

--- a/src/main/java/seedu/address/model/interview/UniqueInterviewList.java
+++ b/src/main/java/seedu/address/model/interview/UniqueInterviewList.java
@@ -42,33 +42,6 @@ public class UniqueInterviewList implements Iterable<Interview> {
     }
 
     /**
-     * Returns true if the interview is passable based off the number of currently
-     * extended offers and position openings.
-     */
-    public boolean isPassableInterview(Interview toPass) {
-        requireNonNull(toPass);
-        return toPass.isPassableInterview();
-    }
-
-    /**
-     * Returns true if the interview is passable based off the current status of
-     * the interview.
-     */
-    public boolean isAcceptableInterview(Interview toAccept) {
-        requireNonNull(toAccept);
-        return toAccept.isAcceptableInterview();
-    }
-
-    /**
-     * Returns true if the interview can be rejected based off the current status of
-     * the interview.
-     */
-    public boolean isRejectableInterview(Interview toReject) {
-        requireNonNull(toReject);
-        return toReject.isRejectableInterview();
-    }
-
-    /**
      * Adds an interview to the list.
      * The interview must not already exist in the list.
      */

--- a/src/test/java/seedu/address/logic/commands/ModelStub.java
+++ b/src/test/java/seedu/address/logic/commands/ModelStub.java
@@ -167,40 +167,6 @@ public class ModelStub implements Model {
     }
 
     @Override
-    public boolean isPassableInterview(Interview interview) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public boolean isAcceptableInterview(Interview interview) {
-        throw new AssertionError("This method should not be called.");
-    }
-
-    @Override
-    public boolean isRejectableInterview(Interview interview) {
-        throw new AssertionError("This method should not be called.");
-    }
-    //        @Override
-    //        public void passInterview(Interview interview) {
-    //            throw new AssertionError("This method should not be called.");
-    //        }
-    //
-    //        @Override
-    //        public void failInterview(Interview interview) {
-    //            throw new AssertionError("This method should not be called.");
-    //        }
-    //
-    //        @Override
-    //        public void acceptInterview(Interview interview) {
-    //            throw new AssertionError("This method should not be called.");
-    //        }
-    //
-    //        @Override
-    //        public void rejectInterview(Interview interview) {
-    //            throw new AssertionError("This method should not be called.");
-    //        }
-
-    @Override
     public void setInterview(Interview target, Interview editedInterview) {
         throw new AssertionError("This method should not be called.");
     }


### PR DESCRIPTION
All interview involving status changes now calls `interview` level methods for checking instead of going through the model. This makes all code for status changes more consistent.

Close #274 

