### PR TITLE
Update name of logging file created

### DIFF
--- a/src/main/java/seedu/address/commons/core/LogsCenter.java
+++ b/src/main/java/seedu/address/commons/core/LogsCenter.java
@@ -18,7 +18,7 @@ import java.util.logging.SimpleFormatter;
 public class LogsCenter {
     private static final int MAX_FILE_COUNT = 5;
     private static final int MAX_FILE_SIZE_IN_BYTES = (int) (Math.pow(2, 20) * 5); // 5MB
-    private static final String LOG_FILE = "addressbook.log";
+    private static final String LOG_FILE = "hirelah.log";
     private static Level currentLogLevel = Level.INFO;
     private static final Logger logger = LogsCenter.getLogger(LogsCenter.class);
     private static FileHandler fileHandler;


### PR DESCRIPTION
Fix #135 

The logging files created will now be named `HireLah.log`

<img width="238" alt="image" src="https://user-images.githubusercontent.com/68813082/162445353-613049a4-cba9-4fc5-9958-dacb2d583f1f.png">
