### PR TITLE
Update UI to fix issues

### DIFF
--- a/src/main/resources/view/ApplicantListCard.fxml
+++ b/src/main/resources/view/ApplicantListCard.fxml
@@ -28,15 +28,15 @@
             <Region fx:constant="USE_PREF_SIZE" />
           </minWidth>
         </Label>
-        <Label fx:id="name" styleClass="cell_big_label" text="\$first" />
+        <Label fx:id="name" styleClass="cell_big_label" text="\$first" wrapText="true"/>
       </HBox>
       <FlowPane fx:id="tags" prefWidth="320"/>
         <HBox alignment="CENTER_LEFT" spacing="20">
             <Label fx:id="gender" styleClass="cell_small_label" text="\$gender"/>
             <Label fx:id="age" styleClass="cell_small_label" text="\$age"/>
         </HBox>
-      <Label fx:id="address" styleClass="cell_small_label" text="\$address" />
-        <Label fx:id="email" styleClass="cell_small_label" text="\$email" />
+      <Label fx:id="address" styleClass="cell_small_label" text="\$address" wrapText="true"/>
+        <Label fx:id="email" styleClass="cell_small_label" text="\$email" wrapText="true"/>
         <Label fx:id="phone" styleClass="cell_small_label" text="\$phone" />
     </VBox>
       </center>

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -8,7 +8,7 @@
 <?import javafx.scene.layout.*?>
 <?import javafx.stage.*?>
 
-<fx:root resizable="false" title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root title="Help" type="javafx.stage.Stage" xmlns="http://javafx.com/javafx/16" xmlns:fx="http://javafx.com/fxml/1">
   <icons>
     <Image url="@/images/help_icon.png" />
   </icons>
@@ -23,7 +23,8 @@
               <Insets bottom="10" left="10" right="10" top="5" />
           </padding>
         <children>
-          <Label fx:id="helpMessage" prefWidth="520" style="-fx-wrap-text: true" text="Label" />
+
+          <Label fx:id="helpMessage" prefWidth="520" style="-fx-wrap-text: true" text="Label" wrapText="true" />
             <BorderPane>
                 <left>
                     <Label fx:id="ugMessage" BorderPane.alignment="CENTER" />

--- a/src/main/resources/view/InterviewListCard.fxml
+++ b/src/main/resources/view/InterviewListCard.fxml
@@ -16,7 +16,7 @@
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
       <BorderPane>
-          <left>
+          <center>
     <VBox alignment="CENTER_LEFT" minHeight="60" GridPane.columnIndex="0">
       <padding>
         <Insets bottom="10" left="15" right="5" top="10" />
@@ -35,7 +35,7 @@
         <Label fx:id="interviewphone" styleClass="cell_small_label" text="\$phone"/>
         <Label fx:id="interviewemail" styleClass="cell_small_label" text="\$email"/>
     </VBox>
-          </left>
+          </center>
           <right>
               <VBox alignment="TOP_RIGHT" >
                   <padding>

--- a/src/main/resources/view/InterviewListCard.fxml
+++ b/src/main/resources/view/InterviewListCard.fxml
@@ -30,8 +30,8 @@
         </Label>
         <Label fx:id="date" styleClass="cell_big_label" text="\$date" />
       </HBox>
-        <Label fx:id="role" styleClass="cell_small_label" text="\$role" />
-      <Label fx:id="name" styleClass="cell_medium_label" text="\$name"/>
+        <Label fx:id="role" styleClass="cell_small_label" text="\$role" wrapText="true"/>
+      <Label fx:id="name" styleClass="cell_medium_label" text="\$name" wrapText="true"/>
         <Label fx:id="interviewphone" styleClass="cell_small_label" text="\$phone"/>
         <Label fx:id="interviewemail" styleClass="cell_small_label" text="\$email"/>
     </VBox>


### PR DESCRIPTION
Fix #322, the fields in applicants now wrap when too long

<img width="429" alt="image" src="https://user-images.githubusercontent.com/68813082/162625773-7c76de09-5098-4617-aad3-411d573276ba.png">

Fix #325, the interview status will stay now

<img width="423" alt="image" src="https://user-images.githubusercontent.com/68813082/162625800-6c072664-142f-4c78-bfa9-5e9119e543bf.png">

Fix #330, the help window can now be resized
